### PR TITLE
Bugfixes permalink regex

### DIFF
--- a/includes/controller/Main.php
+++ b/includes/controller/Main.php
@@ -189,7 +189,7 @@
                 }
             }
 
-            if (preg_match("/$url_regex/", ltrim($request, '/'), $matches)) {
+            if (preg_match("/^$url_regex$/", ltrim($request, '/'), $matches)) {
                 $post_url_attrs = array();
                 for ($i = 0; $i < count($url_parameters); $i++) {
                     $post_url_attrs[$url_parameters[$i]] = urldecode($matches[$i + 1]);

--- a/includes/controller/Main.php
+++ b/includes/controller/Main.php
@@ -189,7 +189,7 @@
                 }
             }
 
-            if (preg_match("/$url_regex/", trim($request, '/'), $matches)) {
+            if (preg_match("/$url_regex/", ltrim($request, '/'), $matches)) {
                 $post_url_attrs = array();
                 for ($i = 0; $i < count($url_parameters); $i++) {
                     $post_url_attrs[$url_parameters[$i]] = urldecode($matches[$i + 1]);


### PR DESCRIPTION
1. A trailing slash in the permalink template caused permalinks to fail
2. Nonanchored permalink regex matched arbitrary pre- and sffixes
