### PR TITLE
Fix #15 - Garbage after "Read More"-Link

### DIFF
--- a/modules/read_more/read_more.php
+++ b/modules/read_more/read_more.php
@@ -26,7 +26,7 @@
             if (Route::current()->action == "view")
                 return preg_replace('/(<p>)?<a class="read_more" href="([^"]+)">e51b2b9a58824dd068d8777ec6e97e4d<\/a>\(\(\(more(\((.+)\))?\)\)\)(<\/p>(\n\n<\/p>(\n\n)?)?)?/', "", $text);
 
-            preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/", preg_replace("/<[^>]+>/", "", $text), $more, PREG_OFFSET_CAPTURE);
+            preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/", preg_replace("/<[^>]+>/", "", html_entity_decode($text, ENT_QUOTES)), $more, PREG_OFFSET_CAPTURE);
             $body = truncate($text, $more[1][0][1], "", true, true);
             $body.= @$more[3][0];
 


### PR DESCRIPTION
This is the fix @PolarLava already proposed in the issue discussion, I just had to make sure it was _really_ due to the entity counting.

The scary regexes in `read_more.php` need some descarifying too, but I don't know if I can get to this before the end of the week. 
