### PR TITLE
Removed long conversion for IPs. (Change that WILL BREAK THINGS)

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -57,6 +57,7 @@
             $config->remove("auto_reload_comments");
             $config->remove("enable_reload_comments");
             $config->remove("allow_nested_comments");
+            $config->remove("ip_converted_to_varchar");
 
             Group::remove_permission("add_comment");
             Group::remove_permission("add_comment_private");
@@ -738,7 +739,7 @@
                 $atom.= "                <uri>".fix($comment->author_url)."</uri>\r";
                 $atom.= "                <email>".fix($comment->author_email)."</email>\r";
                 $atom.= "                <chyrp:login>".fix(@$comment->user->login)."</chyrp:login>\r";
-                $atom.= "                <chyrp:ip>".long2ip($comment->author_ip)."</chyrp:ip>\r";
+                $atom.= "                <chyrp:ip>".$comment->author_ip."</chyrp:ip>\r";
                 $atom.= "                <chyrp:agent>".fix($comment->author_agent)."</chyrp:agent>\r";
                 $atom.= "            </author>\r";
                 $atom.= "            <content>".fix($comment->body)."</content>\r";

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -57,7 +57,6 @@
             $config->remove("auto_reload_comments");
             $config->remove("enable_reload_comments");
             $config->remove("allow_nested_comments");
-            $config->remove("ip_converted_to_varchar");
 
             Group::remove_permission("add_comment");
             Group::remove_permission("add_comment_private");
@@ -739,7 +738,7 @@
                 $atom.= "                <uri>".fix($comment->author_url)."</uri>\r";
                 $atom.= "                <email>".fix($comment->author_email)."</email>\r";
                 $atom.= "                <chyrp:login>".fix(@$comment->user->login)."</chyrp:login>\r";
-                $atom.= "                <chyrp:ip>".$comment->author_ip."</chyrp:ip>\r";
+                $atom.= "                <chyrp:ip>".$this->handle_ip($comment->author_ip)."</chyrp:ip>\r";
                 $atom.= "                <chyrp:agent>".fix($comment->author_agent)."</chyrp:agent>\r";
                 $atom.= "            </author>\r";
                 $atom.= "            <content>".fix($comment->body)."</content>\r";
@@ -772,5 +771,11 @@
                 return "(0)";
             else
                 return QueryBuilder::build_list($_SESSION['comments']);
+        }
+
+        public function handle_ip($ip) {
+            if (long2ip(ip2long($ip)) == "0.0.0.0")
+               return long2ip($ip);
+            return $ip;
         }
     }

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -57,7 +57,6 @@
             $config->remove("auto_reload_comments");
             $config->remove("enable_reload_comments");
             $config->remove("allow_nested_comments");
-            $config->remove("ip_converted_to_varchar");
 
             Group::remove_permission("add_comment");
             Group::remove_permission("add_comment_private");

--- a/modules/comments/model.Comment.php
+++ b/modules/comments/model.Comment.php
@@ -177,7 +177,7 @@
                 if (!@parse_url($url, PHP_URL_SCHEME))
                     $url = "http://".$url;
 
-            $ip = ip2long($ip);
+            //$ip = ip2long($ip);
             if ($ip === false)
                 $ip = 0;
 

--- a/modules/comments/upgrades.php
+++ b/modules/comments/upgrades.php
@@ -30,6 +30,11 @@
                 test(SQL::current()->query("ALTER TABLE __comments ADD notify INTEGER DEFAULT 0 AFTER parent_id"));
     }
 
+    function update_ip_field() {
+        echo __("Replacing author_id column with a varchar...", "comments").
+        test(SQL::current()->query("ALTER TABLE __comments MODIFY author_ip VARCHAR(128)"));
+    }
+    
     Config::fallback("auto_reload_comments", 30);
     Config::fallback("enable_reload_comments", false);
 
@@ -37,3 +42,4 @@
     remove_defensio_set_akismet();
     add_comment_parent_id_field();
     add_comment_notify_field();
+    update_ip_field();


### PR DESCRIPTION
The long conversion causes confusion and I don't know why it was implemented. This commit changes the structure of the "comments" table to do this. However, this patch will break. If you care about your comments, back up the comments table and run:

alter table comments modify author_ip varchar(128);

However, backward compatibility SHOULD be preserved. Please review this patch carefully.
