### PR TITLE
EmailBlog: Other IMAP servers supported (in theory)

### DIFF
--- a/modules/emailblog/emailblog.php
+++ b/modules/emailblog/emailblog.php
@@ -13,6 +13,7 @@
 
         static function __install() {
                 $config = Config::current();
+                $config->set("emailblog_server", "imap.gmail.com:993/ssl/novalidate-cert");
                 $config->set("emailblog_address", "example@gmail.com");
                 $config->set("emailblog_pass", "password");
                 $config->set("emailblog_subjpass", "BlogPost");
@@ -27,6 +28,7 @@
             $config->remove("emailblog_subjpass");
             $config->remove("emailblog_mail_checked");
             $config->remove("emailblog_minutes");
+            $config->remove("emailblog_server");
         }
 
         static function admin_emailblog_settings($admin) {
@@ -43,7 +45,8 @@
             $set = array($config->set("emailblog_address", $_POST['email']),
                          $config->set("emailblog_pass", $_POST['pass']),
                          $config->set("emailblog_minutes", $_POST['minutes']),
-                         $config->set("emailblog_subjpass", $_POST['subjpass']));
+                         $config->set("emailblog_subjpass", $_POST['subjpass']),
+                         $config->set("emailblog_server", $_POST['server']));
 
             if (!in_array(false, $set))
                 Flash::notice(__("Settings updated."), "/admin/?action=emailblog_settings");
@@ -62,7 +65,7 @@
         function getMail(){
             $config = Config::current();
             if (time() - (60 * $config->emailblog_minutes) >= $config->emailblog_mail_checked) {
-                    $hostname = '{imap.gmail.com:993/ssl/novalidate-cert}INBOX';
+                    $hostname = '{'.$config->emailblog_server.'}INBOX';
                     # this isn't working well on localhost
                     $username = $config->emailblog_address;
                     $password = $config->emailblog_pass;

--- a/modules/emailblog/locale/en_US.pot
+++ b/modules/emailblog/locale/en_US.pot
@@ -18,7 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: modules/emailblog/pages/admin/emailblog_settings.twig:9
-msgid "Email Address"
+msgid "IMAP Server"
+msgstr ""
+
+#: modules/emailblog/pages/admin/emailblog_settings.twig:9
+msgid "Username"
 msgstr ""
 
 #: modules/emailblog/pages/admin/emailblog_settings.twig:14
@@ -26,7 +30,7 @@ msgid "Email Password"
 msgstr ""
 
 #: modules/emailblog/info.yaml:6
-msgid "Allows you to email a gmail account to post a new message."
+msgid "Allows you to email to post a new message."
 msgstr ""
 
 #: modules/emailblog/pages/admin/emailblog_settings.twig:19
@@ -34,7 +38,7 @@ msgid "Email Filter"
 msgstr ""
 
 #: modules/emailblog/pages/admin/emailblog_settings.twig:11
-msgid "Currently only supports GMail accounts."
+msgid "The address to your IMAP server."
 msgstr ""
 
 #: modules/emailblog/pages/admin/emailblog_settings.twig:27

--- a/modules/emailblog/locale/en_US.pot
+++ b/modules/emailblog/locale/en_US.pot
@@ -38,7 +38,7 @@ msgid "Email Filter"
 msgstr ""
 
 #: modules/emailblog/pages/admin/emailblog_settings.twig:11
-msgid "The address to your IMAP server."
+msgid "The address to your IMAP server. If you don't know it, just leave this at the default and use Gmail."
 msgstr ""
 
 #: modules/emailblog/pages/admin/emailblog_settings.twig:27

--- a/modules/emailblog/pages/admin/emailblog_settings.twig
+++ b/modules/emailblog/pages/admin/emailblog_settings.twig
@@ -8,7 +8,7 @@
                     <p>
                         <label for="server">${ "IMAP Server" | translate("emailblog") }</label>
                         <input class="text" type="text" name="server" value="${ site.emailblog_server | escape }" id="email" />
-                        <small>${ "The address to your IMAP server." | translate("emailblog") }</small>
+                        <small>${ "The address to your IMAP server. If you don't know it, just leave this at the default and use Gmail." | translate("emailblog") }</small>
                     </p>
                     <p>
                         <label for="email">${ "Username" | translate("emailblog") }</label>

--- a/modules/emailblog/pages/admin/emailblog_settings.twig
+++ b/modules/emailblog/pages/admin/emailblog_settings.twig
@@ -6,9 +6,14 @@
             <form id="comment_settings" class="split" action="{% admin "emailblog_settings" %}" method="post">
                 <fieldset>
                     <p>
-                        <label for="email">${ "Email Address" | translate("emailblog") }</label>
+                        <label for="server">${ "IMAP Server" | translate("emailblog") }</label>
+                        <input class="text" type="text" name="server" value="${ site.emailblog_server | escape }" id="email" />
+                        <small>${ "The address to your IMAP server." | translate("emailblog") }</small>
+                    </p>
+                    <p>
+                        <label for="email">${ "Username" | translate("emailblog") }</label>
                         <input class="text" type="text" name="email" value="${ site.emailblog_address | escape }" id="email" />
-                        <small>${ "Currently only supports GMail accounts." | translate("emailblog") }</small>
+                        <small>${ "Your username on the IMAP server, usually your email." | translate("emailblog") }</small>
                     </p>
                      <p>
                         <label for="pass">${ "Email Password" | translate("emailblog") }</label>


### PR DESCRIPTION
I have tested this with Gmail. It seems to work okay.

I have nothing against Gmail, but there might be some Chyrp user who doesn't want to use Gmail, or want to use their own custom domain with a IMAP server but not use Google Apps.
