### PR TITLE
Fix thumb.php to use null instead of "" for imagejpeg filename argument

### DIFF
--- a/includes/thumb.php
+++ b/includes/thumb.php
@@ -178,7 +178,7 @@
 
     # Serve the image.
     if ($done == "imagejpeg")
-        $done($thumbnail, "", $quality);
+        $done($thumbnail, null, $quality);
     else
         $done($thumbnail);
 


### PR DESCRIPTION
Prevents failure on generating thumbnails for JPEG images
