### PR TITLE
Chyrp Update remote checker fix for those with allow_url_fopen enabled.

### DIFF
--- a/includes/class/Update.php
+++ b/includes/class/Update.php
@@ -9,7 +9,7 @@
          * Loads the update XML file.
          */
         private static function xml() {
-            $xml = simplexml_load_file("http://chyrp.net/update.xml");
+            $xml = simplexml_load_string(get_remote("http://chyrp.net/update.xml"));
             return $xml;
         }
 


### PR DESCRIPTION
Replace simplexml_load_file() which depends on allow_url_fopen to work for those which have it disabled.

It's only a one line change so the diff is pretty self explanatory.  :) 
