### PR TITLE
Entity fixes for read_more and Atom feed.

### DIFF
--- a/includes/class/Update.php
+++ b/includes/class/Update.php
@@ -9,7 +9,7 @@
          * Loads the update XML file.
          */
         private static function xml() {
-            $xml = simplexml_load_file("http://chyrp.net/update.xml");
+            $xml = simplexml_load_string(get_remote("http://chyrp.net/update.xml"));
             return $xml;
         }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -457,7 +457,7 @@
      *     $quotes - Encode quotes?
      *     $double - Encode encoded?
      */
-    function fix($string, $quotes = false, $double = false) {
+    function fix($string, $quotes = false, $double = true) {
         $quotes = ($quotes) ? ENT_QUOTES : ENT_NOQUOTES ;
         return htmlspecialchars($string, $quotes, "utf-8", $double);
     }

--- a/modules/read_more/read_more.php
+++ b/modules/read_more/read_more.php
@@ -26,11 +26,17 @@
             if (Route::current()->action == "view")
                 return preg_replace('/(<p>)?<a class="read_more" href="([^"]+)">e51b2b9a58824dd068d8777ec6e97e4d<\/a>\(\(\(more(\((.+)\))?\)\)\)(<\/p>(\n\n<\/p>(\n\n)?)?)?/', "", $text);
 
-            preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/",
-                           preg_replace("/<[^>]+>/", "", html_entity_decode(str_replace("&nbsp;", " ", $text), ENT_QUOTES)),
-                           $more, PREG_OFFSET_CAPTURE);
-
-            $body = truncate($text, $more[1][0][1], "", true, true);
+            if (module_enabled('smartypants')) {
+                preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/",
+                               preg_replace("/<[^>]+>/", "", html_entity_decode(Smartypants::stupify($text), ENT_QUOTES, 'UTF-8')),
+                               $more, PREG_OFFSET_CAPTURE);
+                $body = truncate(html_entity_decode(Smartypants::stupify($text), ENT_QUOTES, 'UTF-8'), $more[1][0][1], "", true, true);
+            } else {
+                preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/",
+                               preg_replace("/<[^>]+>/", "", html_entity_decode(str_replace("&nbsp;", " ", $text), ENT_QUOTES, 'UTF-8')),
+                               $more, PREG_OFFSET_CAPTURE);
+                $body = truncate($text, $more[1][0][1], "", true, true);
+            }
             $body.= @$more[3][0];
 
             if (!empty($more[2][0]))

--- a/modules/smartypants/smartypants.php
+++ b/modules/smartypants/smartypants.php
@@ -6,8 +6,14 @@
             $this->addAlias("markup_text", "smartify", 9);
             $this->addAlias("markup_title", "smartify", 9);
             $this->addAlias("preview", "smartify", 9);
+            $this->addAlias("unmarkup_text", "stupify", 9);
+            $this->addAlias("unmarkup_title", "stupify", 9);
         }
         static function smartify($text) {
             return Smartypants($text);
+        }
+	
+	static function stupify($text, $attr = -1) {
+            return Smartypants($text, $attr);
         }
     }


### PR DESCRIPTION
There are two parts to this fix, the first changes the default function parameter $double to TRUE in fix() function.  Grepping the code this parameter isn't used anywhere else at this time.  This change allows HTML entities in the Atom feed to be handled properly.

The second part is a continuation of the entity handling in the read_more module that was previously dealt on issues #15, #35 and #135.  This change adds support for proper handling of entities when using the Smartypants module.  As part of this, there is addition there that enables the "stupify" functionality.  This is functionality that exists in Smartypants but wasn't accessible.  "stupify" is their term for un-Smartypants-ing the content passed through it.  This is something I'm quite familiar with as I [previous have contributed changes back to the original Smartpants-PHP project](http://monauraljerk.org/smartypants-php/CHANGELOG).
