### PR TITLE
Fix Categorize module Atom feed category syntax so the feed validates properly.

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -457,7 +457,7 @@
      *     $quotes - Encode quotes?
      *     $double - Encode encoded?
      */
-    function fix($string, $quotes = false, $double = false) {
+    function fix($string, $quotes = false, $double = true) {
         $quotes = ($quotes) ? ENT_QUOTES : ENT_NOQUOTES ;
         return htmlspecialchars($string, $quotes, "utf-8", $double);
     }

--- a/modules/categorize/categorize.php
+++ b/modules/categorize/categorize.php
@@ -25,7 +25,7 @@
     
         public function feed_item($post) {
             if (!empty($post->category_id) OR $post->category != 0)
-               printf("\t<category>%s</category>\n", Category::getCategory($post->category_id)->name);
+               printf("\t<category term=\"%s\" />\n", Category::getCategory($post->category_id)->name);
         }
     
         /* XML Stuff */

--- a/modules/read_more/read_more.php
+++ b/modules/read_more/read_more.php
@@ -26,11 +26,17 @@
             if (Route::current()->action == "view")
                 return preg_replace('/(<p>)?<a class="read_more" href="([^"]+)">e51b2b9a58824dd068d8777ec6e97e4d<\/a>\(\(\(more(\((.+)\))?\)\)\)(<\/p>(\n\n<\/p>(\n\n)?)?)?/', "", $text);
 
-            preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/",
-                           preg_replace("/<[^>]+>/", "", html_entity_decode(str_replace("&nbsp;", " ", $text), ENT_QUOTES)),
-                           $more, PREG_OFFSET_CAPTURE);
-
-            $body = truncate($text, $more[1][0][1], "", true, true);
+            if (module_enabled('smartypants')) {
+                preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/",
+                               preg_replace("/<[^>]+>/", "", html_entity_decode(Smartypants::stupify($text), ENT_QUOTES, 'UTF-8')),
+                               $more, PREG_OFFSET_CAPTURE);
+                $body = truncate(html_entity_decode(Smartypants::stupify($text), ENT_QUOTES, 'UTF-8'), $more[1][0][1], "", true, true);
+            } else {
+                preg_match_all("/e51b2b9a58824dd068d8777ec6e97e4d(\(\(\(more(\((.+)\))?\)\)\))/",
+                               preg_replace("/<[^>]+>/", "", html_entity_decode(str_replace("&nbsp;", " ", $text), ENT_QUOTES, 'UTF-8')),
+                               $more, PREG_OFFSET_CAPTURE);
+                $body = truncate($text, $more[1][0][1], "", true, true);
+            }
             $body.= @$more[3][0];
 
             if (!empty($more[2][0]))

--- a/modules/smartypants/smartypants.php
+++ b/modules/smartypants/smartypants.php
@@ -6,8 +6,14 @@
             $this->addAlias("markup_text", "smartify", 9);
             $this->addAlias("markup_title", "smartify", 9);
             $this->addAlias("preview", "smartify", 9);
+            $this->addAlias("unmarkup_text", "stupify", 9);
+            $this->addAlias("unmarkup_title", "stupify", 9);
         }
         static function smartify($text) {
             return Smartypants($text);
+        }
+	
+	static function stupify($text, $attr = -1) {
+            return Smartypants($text, $attr);
         }
     }


### PR DESCRIPTION
Another one -line fix.  Currently validating the Atom feed when using the Categorize module results in a "Missing category attribute: term" error.  This is due to the tag being incorrectly set as

```
<category>CAT_NAME</category>
```

when it should be

```
<category term="CAT_NAME" />
```
