### PR TITLE
Fixed modules conflicting with inline editing

### DIFF
--- a/feathers/photo/photo.php
+++ b/feathers/photo/photo.php
@@ -70,6 +70,10 @@
             } else
                 $filename = $_POST['filename'];
 
+            // Prepend scheme if a URL is detected
+            if (preg_match('~^((([a-z]|[0-9]|\-)+)\.)+([a-z]){2,6}/~', @$_POST['option']['source']))
+                $_POST['option']['source'] = "http://".$_POST['option']['source'];
+
             return Post::add(array("filename" => $filename,
                                    "caption" => $_POST['caption']),
                              $_POST['slug'],
@@ -90,6 +94,10 @@
                 $this->delete_file($post);
                 $filename = $_POST['filename'];
             }
+
+            // Prepend scheme if a URL is detected
+            if (preg_match('~^((([a-z]|[0-9]|\-)+)\.)+([a-z]){2,6}/~', @$_POST['option']['source']))
+                $_POST['option']['source'] = "http://".$_POST['option']['source'];
 
             $post->update(array("filename" => $filename,
                                 "caption" => $_POST['caption']));

--- a/feathers/photo/photo.php
+++ b/feathers/photo/photo.php
@@ -70,7 +70,7 @@
             } else
                 $filename = $_POST['filename'];
 
-            // Prepend scheme if a URL is detected
+            # Prepend scheme if a URL is detected
             if (preg_match('~^((([a-z]|[0-9]|\-)+)\.)+([a-z]){2,6}/~', @$_POST['option']['source']))
                 $_POST['option']['source'] = "http://".$_POST['option']['source'];
 
@@ -95,7 +95,7 @@
                 $filename = $_POST['filename'];
             }
 
-            // Prepend scheme if a URL is detected
+            # Prepend scheme if a URL is detected
             if (preg_match('~^((([a-z]|[0-9]|\-)+)\.)+([a-z]){2,6}/~', @$_POST['option']['source']))
                 $_POST['option']['source'] = "http://".$_POST['option']['source'];
 

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -461,8 +461,6 @@
         }
 
         static function ajax() {
-            header("Content-Type: application/x-javascript", true);
-
             $config  = Config::current();
             $sql     = SQL::current();
             $trigger = Trigger::current();

--- a/modules/likes/likes.php
+++ b/modules/likes/likes.php
@@ -64,7 +64,7 @@
             return $scripts;
         }
 
-        static function ajax() {
+        static function ajax_like() {
             header("Content-type: text/json");
             header("Content-Type: application/x-javascript", true);
 
@@ -81,6 +81,8 @@
                 $likeText = "";
                 switch ($like->action) {
                 	case "like":
+                        header("Content-type: text/json");
+                        header("Content-Type: application/x-javascript", true);
                         $like->like();
                         $like->fetchCount();
                         if ($like->total_count == 1)
@@ -95,19 +97,47 @@
                         	$likeText = $like->getText($like->total_count, $likeSetting["likeText"][2]);
                         }
                 	break;
-                	case "unlike":
+                	default: throw new Exception("invalid action");
+                }
+
+                $responseObj["likeText"] = $likeText;
+            }
+            catch(Exception $e) {
+                $responseObj["success"] = false;
+                $responseObj["error_txt"] = $e->getMessage();
+            }
+            echo json_encode($responseObj);
+        }
+
+        static function ajax_unlike() {
+            header("Content-type: text/json");
+            header("Content-Type: application/x-javascript", true);
+
+            if (!isset($_REQUEST["action"]) or !isset($_REQUEST["post_id"])) exit();
+            
+            $user_id = Visitor::current()->id;
+            $likeSetting = Config::current()->module_like;
+            $responseObj = array();
+            $responseObj["uid"] = $user_id;
+            $responseObj["success"] = true;
+            
+            try {
+                $like = new Like($_REQUEST, $user_id);
+                $likeText = "";
+                switch ($like->action) {
+                    case "unlike":
                         $like->unlike();
                         $like->fetchCount();
                         if ($like->total_count > 1) {
                             # $this->text_default[5] = "%NUM% people like this post.";
                             $likeText = $like->getText($like->total_count, $likeSetting["likeText"][5]);
                         } elseif ($like->total_count == 1) {
-                        	# $this->text_default[4] = "1 person likes this post.";
-                        	$likeText = $like->getText($like->total_count, $likeSetting["likeText"][4]);
+                            # $this->text_default[4] = "1 person likes this post.";
+                            $likeText = $like->getText($like->total_count, $likeSetting["likeText"][4]);
                         } elseif ($like->total_count == 0)
-                        	$likeText = $like->getText($like->total_count, $likeSetting["likeText"][3]);
-                	break;
-                	default: throw new Exception("invalid action");
+                            $likeText = $like->getText($like->total_count, $likeSetting["likeText"][3]);
+                    break;
+                    default: throw new Exception("invalid action");
                 }
 
                 $responseObj["likeText"] = $likeText;

--- a/modules/read_more/read_more.php
+++ b/modules/read_more/read_more.php
@@ -6,6 +6,9 @@
 
         # Replace the "read more" indicator before markup modules get to it.
         static function makesafe($text, $post = null) {
+            # Catch posts created with the WYSIWYG editor
+            if (is_string($text)) $text = str_replace("&lt;!--more--&gt;", "<!--more-->", $text);
+
             if (!is_string($text) or !preg_match("/<!--more(\((.+)\))?-->/", $text)) return $text;
 
             $controller = Route::current()->controller;


### PR DESCRIPTION
Misbehaving ajax functions in Like and Comments modules were breaking the inline editing functionality of Chyrp. I modified the functions to get them working properly. Also added URL detection to the [option][source] field of Photo feather, to allow submission of absolute URLs without a scheme; this is a workaround for servers with aggressive ModSec rules.
