### PR TITLE
Fixing errors added during latest merge/pull

### DIFF
--- a/includes/lib/plugins.js
+++ b/includes/lib/plugins.js
@@ -365,18 +365,3 @@ $(document).ready(function() {
   $('.post:not(.chat) .subpost').not(':has(h2.title)').addClass('no_title');
 });
 
-$(window).load(function() {
-  var top = $('.redactor_toolbar').offset().top;
-  $(window).scroll(function() {
-    var windowLocation = $(window).scrollTop();
-    if (windowLocation > top) {
-      $('.redactor_toolbar').css({"position":"fixed"});
-      $('.redactor_box').css({"margin-top":"33px"});
-      $('.redactor_box ul').css({"border-left":"1px solid #ddd","border-right":"1px solid #ddd"});
-    } else {
-      $('.redactor_toolbar').css({"position":"static"});
-      $('.redactor_box').css({"margin-top":"0"});
-      $('.redactor_box ul').css({"border-left":"none","border-right":"none"});
-    }
-  });
-});

--- a/includes/lib/redactor/redactor.css
+++ b/includes/lib/redactor/redactor.css
@@ -250,11 +250,8 @@ body .redactor_box_fullscreen {
 */
 .redactor_toolbar {
 	font-family: Helvetica, Arial, Verdana, Tahoma, sans-serif !important;
-<<<<<<< HEAD
-=======
 	position: absolute;
 	width: 100%;
->>>>>>> 141a45b13ed50d006b2525065c37353af8e787f8
 	left: 0;
 	right: 0;
 	top: 0;


### PR DESCRIPTION
_redactor.css_ has bad syntax that is causing problems, and _plugins.js_ contains code superseded by my stickyToolbar function in the same file. This is making a mess of the redactor sticky toolbar.
