### PR TITLE
Support for HTML5 "multiple" flag in file inputs

### DIFF
--- a/admin/themes/default/partials/post_fields.twig
+++ b/admin/themes/default/partials/post_fields.twig
@@ -16,7 +16,7 @@
                             {% endif %}
                         </label>
                         {% if field.type == "text" or field.type == "file" %}
-                        <input class="$field.type{% if field.classes %} ${ field.classes | join(" ") }{% endif %}" type="$field.type" name="$field.attr" value="{% if not field.no_value %}${ field.value | fallback(post[field.attr] | escape(true, false)) }{% endif %}" id="${ field.attr }_field" />
+                        <input class="$field.type{% if field.classes %} ${ field.classes | join(" ") }{% endif %}" type="$field.type" name="$field.attr{% if field.multiple == "true" %}[]" multiple{% else %}"{% endif %} value="{% if not field.no_value %}${ field.value | fallback(post[field.attr] | escape(true, false)) }{% endif %}" id="${ field.attr }_field" />
                         {% if field.type == "file" and post.filename and route.action == "edit_post" %}
                         <em>Current file name: <strong>${ post.filename | escape('') }</strong></em>
                         {% endif %}

--- a/themes/firecrest/forms/post/edit.twig
+++ b/themes/firecrest/forms/post/edit.twig
@@ -10,7 +10,7 @@
                             {% endif %}
                         </label>
                         {% if field.type == "text" or field.type == "file" %}
-                        <input class="$field.type{% if field.classes %} ${ field.classes | join(" ") }{% endif %}" type="$field.type" name="$field.attr" value="{% if not field.no_value %}${ field.value | fallback(post[field.attr] | escape(true, false)) }{% endif %}" id="$field.attr" />
+                        <input class="$field.type{% if field.classes %} ${ field.classes | join(" ") }{% endif %}" type="$field.type" name="$field.attr{% if field.multiple == "true" %}[]" multiple{% else %}"{% endif %} value="{% if not field.no_value %}${ field.value | fallback(post[field.attr] | escape(true, false)) }{% endif %}" id="$field.attr" />
                         {% elseif field.type == "text_block" %}
                         <textarea class="wide{% if field.classes %} ${ field.classes | join(" ") }{% endif %}" rows="${ field.rows | fallback(12) }" name="$field.attr" id="$field.attr" cols="50">{% if not field.no_value %}${ field.value | fallback(post[field.attr] | escape(false, false)) }{% endif %}</textarea>
                         {% elseif field.type == "checkbox" %}

--- a/themes/firecrest/stylesheets/screen.css
+++ b/themes/firecrest/stylesheets/screen.css
@@ -443,7 +443,7 @@ div.post .no_title {
         z-index: 1;
     }*/
 div.post .feather_type {
-    position: relative;
+    position: absolute;
     margin-left: -47px;
     top: 1.66em;
 }
@@ -465,7 +465,7 @@ div.post .feather_type_name {
 div.post .feather_type span.shadow {
     background: url(../images/post-tag-shadow.png) top left no-repeat;
     position: absolute;
-    top: 27px;
+    bottom: -4px;
     left: 0;
     width: 40px;
     height: 4px;


### PR DESCRIPTION
These small changes enable a feather to create a file upload button that allows multiple files to be selected. This is useful for gallery-style feathers and other types of feather that want to implement bulk uploading. Feathers can enable the flag by doing `$this->setField ... "multiple" => "true"`.

Also included is a Firecrest tweak that I merged from @onmoon (becon in the Chyrp forum) that allows Firecrest's feather type labels to support multiple lines of text without messing up the shadow effect.
