### PR TITLE
Setting higher priority for Aggregrator to avoid clash with Categorize module

### DIFF
--- a/modules/aggregator/aggregator.php
+++ b/modules/aggregator/aggregator.php
@@ -1,5 +1,9 @@
 <?php
     class Aggregator extends Modules {
+        public function __construct() {
+            $this->setPriority("main_index", 5);
+        }
+
         static function __install() {
             $config = Config::current();
             $config->set("last_aggregation", 0);


### PR DESCRIPTION
Here's the problem as I understand it:

`main_index` is a trigger action. Both modules, Aggregator and Categorize, contain a function named `main_index` so they will both respond to this trigger when the blog index is loaded by the Main controller.

Categorize responds by using `main->display`, causing the page to be rendered and displayed. It then returns `true` which I assume to be the correct way to tell the Main controller "Hey there! I've caused the page to be displayed, so no need for you to do it. Ok thx bai!"

Aggregrator responds by checking if there is stuff it needs to do, doing that stuff, and then returning `false`.

Now the trouble begins...

If the Aggregator module runs _after_ the Categorize module, it returns false and the Main controller forgets that Categorize returned true – so the controller thinks nobody has displayed the page and _it_ needs to do it. Voila, we get a double page because it's being rendered twice.

You can hack a fix by reordering your modules so that Aggregator runs before Categorize: open your file `config.yaml.php` and in the list of enabled modules, make sure Categorize is the lower of the two, with a higher number than Aggregator.

For the proper fix, this change explicitly sets the priority of Aggregator module to a higher value, ensuring that it runs before Categorize and therefore the Main controller will not get misinformed that it needs to render the page.
