### PR TITLE
A small fix for the cascade module on iOS

### DIFF
--- a/modules/cascade/javascript.php
+++ b/modules/cascade/javascript.php
@@ -19,7 +19,8 @@
             },
             watch: function() {
                 var docViewTop = $(window).scrollTop();
-                var docViewBottom = docViewTop + $(window).height();
+                var windowHeight = window.innerHeight ? window.innerHeight : $(window).height();
+                var docViewBottom = docViewTop + windowHeight;
                 var docViewed = docViewBottom - $(document).height();
                 if ( docViewed == 0 ) ChyrpAjaxScroll.fetch();
             },


### PR DESCRIPTION
Using window.innerHeight where available because on iOS an incorrect value is returned for $(window).height() when zoomed. Tested in iOS 7, and on desktop with Safari, Chrome, Firefox. All good. Fallback should keep us sweet on IE8 (untested).
