### PR TITLE
Admin refactoring, Cascade module update, Audio feather enhancements

### DIFF
--- a/admin/themes/default/javascript.php
+++ b/admin/themes/default/javascript.php
@@ -20,9 +20,7 @@ $(function(){
 var Write = {
     init: function(){
         this.auto_expand_fields()
-
-        if (!$.browser.msie)
-            this.sortable_feathers()
+        this.sortable_feathers()
 
     },
     auto_expand_fields: function(){

--- a/admin/themes/default/javascript.php
+++ b/admin/themes/default/javascript.php
@@ -1,0 +1,522 @@
+<?php
+    define('JAVASCRIPT', true);
+    require_once "../../../includes/common.php";
+    error_reporting(0);
+    header("Content-Type: application/x-javascript");
+    $route = Route::current(MainController::current());
+?>
+<!-- --><script>
+$(function(){
+    if (/(edit|write)_/.test(Route.action))
+        Write.init()
+
+    if (Route.action == "manage_pages")
+        Manage.pages.init()
+
+    if (Route.action == "modules" || Route.action == "feathers")
+        Extend.init()
+})
+
+var Write = {
+    init: function(){
+        this.auto_expand_fields()
+
+        if (!$.browser.msie)
+            this.sortable_feathers()
+
+    },
+    auto_expand_fields: function(){
+        $("input.text").expand()
+    },
+    sortable_feathers: function(){
+        // Make the Feathers sortable
+        $("#sub-nav").sortable({
+            axis: "x",
+            placeholder: "feathers_sort",
+            opacity: 0.8,
+            delay: 1,
+            revert: true,
+            cancel: "a.no_drag, a[href$=write_page]",
+            start: function(e, ui) {
+                $(ui.item).find("a").click(function(){ return false })
+                $(".feathers_sort").width($(ui.item).width() - 2)
+            },
+            update: function(e, ui){
+                $(ui.item).find("a").unbind("click")
+                $.post("<?php echo $config->chyrp_url; ?>/includes/ajax.php",
+                       "action=reorder_feathers&"+ $("#sub-nav").sortable("serialize"))
+            }
+        })
+    }
+}
+
+var Manage = {
+    pages: {
+        init: function(){
+            Manage.pages.prepare_reordering()
+        },
+        parent_hash: function(){
+            var parent_hash = ""
+            $(".sort_pages li").each(function(){
+                var id = $(this).attr("id").replace(/page_list_/, "")
+                var parent = $(this).parent().parent() // this > #sort_pages > page_list_(id)
+                var parent_id = (/page_list_/.test(parent.attr("id"))) ? parent.attr("id").replace(/page_list_/, "") : 0
+                $(this).attr("parent", parent_id)
+                parent_hash += "&parent["+id+"]="+parent_id
+            })
+            return parent_hash
+        },
+        prepare_reordering: function(){
+            $(".sort_pages li div").css({
+                background: "#f9f9f9",
+                padding: ".15em .5em",
+                marginBottom: ".5em",
+                border: "1px solid #ddd",
+                cursor: "move"
+            })
+
+            $("ul.sort_pages").tree({
+                sortOn: "li",
+                dropOn: "li:not(.dragging) div",
+                hoverClass: "sort-hover",
+                done: function(){
+                    $("#content > form > ul.sort_pages").loader()
+                    $.post("<?php echo $config->chyrp_url; ?>/includes/ajax.php",
+                           "action=organize_pages&"+ $("ul.sort_pages").sortable("serialize") + Manage.pages.parent_hash(),
+                           function(){ $("#content > form > ul.sort_pages").loader(true) })
+                }
+            })
+        }
+    }
+}
+
+var Extend = {
+    init: function(){
+        this.prepare_info()
+        this.prepare_draggables()
+
+        if (Route.action != "modules")
+            return
+
+        this.draw_conflicts()
+        this.draw_dependencies()
+
+        $(window).resize(function(){
+            Extend.draw_conflicts()
+            Extend.draw_dependencies()
+        })
+    },
+    Drop: {
+        extension: {
+            classes: [],
+            name: null,
+            type: null
+        },
+        action: null,
+        previous: null,
+        pane: null,
+        confirmed: null
+    },
+    prepare_info: function(){
+        $(".description:not(.expanded)").wrap("<div></div>").parent().hide()
+        $(".info_link").click(function(){
+            $(this).parent().find(".description").parent().slideToggle("normal", Extend.redraw)
+            return false
+        })
+    },
+    prepare_draggables: function(){
+        $(".enable h2, .disable h2").append(" <span class=\"sub desktop\"><?php echo __("(drag)"); ?></span>")
+
+        $(".disable > ul > li:not(.missing_dependency), .enable > ul > li").draggable({
+            zIndex: 100,
+            cancel: "a",
+            revert: true
+        })
+
+        $(".enable > ul, .disable > ul").droppable({
+            accept: "ul.extend > li:not(.missing_dependency)",
+            tolerance: "pointer",
+            activeClass: "active",
+            hoverClass: "hover",
+            drop: Extend.handle_drop
+        })
+
+        $(".enable > ul > li, .disable > ul > li:not(.missing_dependency)").css("cursor", "move")
+
+        Extend.equalize_lists()
+
+        if ($(".feather").size())
+            <?php $tip = _f("(tip: drag the tabs on the <a href=\\\"%s\\\">write</a> page to reorder them)",
+                            array(url("/admin/?action=write"))); ?>
+            $(document.createElement("small")).html("<?php echo $tip; ?>").css({
+                position: "relative",
+                bottom: "-1em",
+                display: "block",
+                textAlign: "center"
+            }).appendTo(".tip_here")
+    },
+    handle_drop: function(ev, ui) {
+        var classes = $(this).parent().attr("class").split(" ")
+
+        Extend.Drop.pane = $(this)
+        Extend.Drop.action = classes[0]
+        Extend.Drop.previous = $(ui.draggable).parent().parent().attr("class").split(" ")[0]
+        Extend.Drop.extension.classes = $(ui.draggable).attr("class").split(" ")
+        Extend.Drop.extension.name = Extend.Drop.extension.classes[0]
+        Extend.Drop.extension.type = classes[1]
+
+        Extend.Drop.confirmed = false
+
+        if (Extend.Drop.previous == Extend.Drop.action)
+            return
+
+        $.post("<?php echo $config->chyrp_url; ?>/includes/ajax.php", {
+            action: "check_confirm",
+            check: Extend.Drop.extension.name,
+            type: Extend.Drop.extension.type
+        }, function(data){
+            if (data != "" && Extend.Drop.action == "disable")
+                Extend.Drop.confirmed = (confirm(data)) ? 1 : 0
+
+            $.ajax({
+                type: "post",
+                dataType: "json",
+                url: "<?php echo $config->chyrp_url; ?>/includes/ajax.php",
+                data: {
+                    action: Extend.Drop.action + "_" + Extend.Drop.extension.type,
+                    extension: Extend.Drop.extension.name,
+                    confirm: Extend.Drop.confirmed
+                },
+                beforeSend: function(){ Extend.Drop.pane.loader() },
+                success: Extend.finish_drop,
+                error: function() {
+                    if (Extend.Drop.action == "enable")
+                        alert("<?php echo __("There was an error enabling the extension."); ?>");
+                    else
+                        alert("<?php echo __("There was an error disabling the extension."); ?>");
+
+                    Extend.Drop.pane.loader(true)
+
+                    $(ui.draggable).css({ left: 0, right: 0, top: 0, bottom: 0 }).appendTo($(".disable ul"))
+
+                    Extend.redraw()
+                }
+            })
+        }, "text")
+
+        $(ui.draggable).css({ left: 0, right: 0, top: 0, bottom: 0 }).appendTo(this)
+
+        Extend.redraw()
+
+        return true
+    },
+    finish_drop: function(json){
+        if (Extend.Drop.action == "enable") {
+            var dependees = Extend.Drop.extension.classes.find(/depended_by_(.+)/)
+            for (i = 0; i < dependees.length; i++) {
+                var dependee = dependees[i].replace("depended_by", "module")
+
+                // The module depending on this one no longer "needs" it
+                $("#"+ dependee).removeClass("needs_"+ Extend.Drop.extension.name)
+
+                // Remove from the dependee's dependency list
+                $("#"+ dependee +" .dependencies_list ."+ Extend.Drop.extension.name).hide()
+
+                if ($("#"+ dependee).attr("class").split(" ").find(/needs_(.+)/).length == 0)
+                    $("#"+ dependee).find(".description").parent().hide().end().end()
+                                    .draggable({
+                                        zIndex: 100,
+                                        cancel: "a",
+                                        revert: true
+                                    })
+                                    .css("cursor", "move")
+            }
+        } else if ($(".depends_"+ Extend.Drop.extension.name).size()) {
+            $(".depends_"+ Extend.Drop.extension.name).find(".description").parent().show()
+            $(".depends_"+ Extend.Drop.extension.name)
+                .find(".dependencies_list")
+                .append($(document.createElement("li")).text(Extend.Drop.extension.name).addClass(Extend.Drop.extension.name))
+                .show()
+                .end()
+                .find(".dependencies_message")
+                .show()
+                .end()
+                .addClass("needs_"+ Extend.Drop.extension.name)
+        }
+
+        Extend.Drop.pane.loader(true)
+        $(json.notifications).each(function(){
+            if (this == "") return
+            alert(this.replace(/<([^>]+)>\n?/gm, ""))
+        })
+
+        Extend.redraw()
+    },
+    equalize_lists: function(){
+        $("ul.extend").height("auto")
+        $("ul.extend").each(function(){
+            if ($(".enable ul.extend").height() > $(this).height())
+                $(this).css('min-height', $(".enable ul.extend").height())
+
+            if ($(".disable ul.extend").height() > $(this).height())
+                $(this).css('min-height', $(".disable ul.extend").height())
+        })
+    },
+    redraw: function(){
+        Extend.equalize_lists()
+        Extend.draw_conflicts()
+        Extend.draw_dependencies()
+    },
+    draw_conflicts: function(){
+        if (!$.support.boxModel ||
+            Route.action != "modules" ||
+            (!$(".extend li.conflict").size()))
+            return false
+
+        $("#conflicts_canvas").remove()
+
+        $("#header, #welcome, #sub-nav, #content a.button, .extend li, #footer, h1, h2").css({
+            position: "relative",
+            zIndex: 2
+        })
+        $("#header ul li a").css({
+            position: "relative",
+            zIndex: 3
+        })
+
+        $(document.createElement("canvas")).attr("id", "conflicts_canvas").prependTo("body")
+        $("#conflicts_canvas").css({
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            zIndex: 1
+        }).attr({ width: $(document).width(), height: $(document).height() })
+
+        var canvas = document.getElementById("conflicts_canvas").getContext("2d")
+        var conflict_displayed = []
+
+        $(".extend li.conflict").each(function(){
+            var classes = $(this).attr("class").split(" ")
+            classes.shift() // Remove the module's safename class
+
+            classes.remove(["conflict",
+                            "depends",
+                            "missing_dependency",
+                            /depended_by_(.+)/,
+                            /needs_(.+)/,
+                            /depends_(.+)/,
+                            /ui-draggable(-dragging)?/])
+
+            for (i = 0; i < classes.length; i++) {
+                var conflict = classes[i].replace("conflict_", "module_")
+
+                if (conflict_displayed[$(this).attr("id")+" :: "+conflict])
+                    continue
+
+                canvas.strokeStyle = "#ef4646"
+                canvas.fillStyle = "#fbe3e4"
+                canvas.lineWidth = 3
+
+                var this_status = $(this).parent().parent().attr("class").split(" ")[0] + "d"
+                var conflict_status = $("#"+conflict).parent().parent().attr("class").split(" ")[0] + "d"
+
+                if (conflict_status != this_status) {
+                    var line_from_x = (conflict_status == "disabled") ?
+                                      $("#"+conflict).offset().left :
+                                      $("#"+conflict).offset().left + $("#"+conflict).outerWidth()
+                    var line_from_y = $("#"+conflict).offset().top + 12
+                    var line_to_x = (conflict_status == "enabled") ?
+                                    $(this).offset().left :
+                                    $(this).offset().left + $(this).outerWidth()
+                    var line_to_y   = $(this).offset().top + 12
+
+                    // Line
+                    canvas.moveTo(line_from_x, line_from_y)
+                    canvas.lineTo(line_to_x, line_to_y)
+                    canvas.stroke()
+                } else if (conflict_status == "disabled") {
+                    var line_from_x = $("#"+conflict).offset().left
+                    var line_from_y = $("#"+conflict).offset().top + 12
+                    var line_to_x   = $(this).offset().left
+                    var line_to_y   = $(this).offset().top + 12
+                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
+                    var curve = line_from_x - 25
+
+                    // Line
+                    canvas.beginPath()
+                    canvas.moveTo(line_from_x, line_from_y)
+                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
+                    canvas.stroke()
+                } else if (conflict_status == "enabled") {
+                    var line_from_x = $("#"+conflict).offset().left + $("#"+conflict).outerWidth()
+                    var line_from_y = $("#"+conflict).offset().top + 12
+                    var line_to_x   = $(this).offset().left + $(this).outerWidth()
+                    var line_to_y   = $(this).offset().top + 12
+                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
+                    var curve = line_from_x + 25
+
+                    // Line
+                    canvas.beginPath()
+                    canvas.moveTo(line_from_x, line_from_y)
+                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
+                    canvas.stroke()
+                }
+
+                // Beginning circle
+                canvas.beginPath()
+                canvas.arc(line_from_x, line_from_y, 5, 0, Math.PI * 2, false)
+                canvas.fill()
+                canvas.stroke()
+
+                // Ending circle
+                canvas.beginPath()
+                canvas.arc(line_to_x, line_to_y, 5, 0, Math.PI * 2, false)
+                canvas.fill()
+                canvas.stroke()
+
+                conflict_displayed[conflict+" :: "+$(this).attr("id")] = true
+            }
+        })
+
+        return true
+    },
+    draw_dependencies: function() {
+        if (!$.support.boxModel ||
+            Route.action != "modules" ||
+            (!$(".extend li.depends").size()))
+            return false
+
+        $("#depends_canvas").remove()
+
+        $("#header, #welcome, #sub-nav, #content a.button, .extend li, #footer, h1, h2").css({
+            position: "relative",
+            zIndex: 2
+        })
+        $("#header ul li a").css({
+            position: "relative",
+            zIndex: 3
+        })
+
+        $(document.createElement("canvas")).attr("id", "depends_canvas").prependTo("body")
+        $("#depends_canvas").css({
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            zIndex: 1
+        }).attr({ width: $(document).width(), height: $(document).height() })
+
+        var canvas = document.getElementById("depends_canvas").getContext("2d")
+        var dependency_displayed = []
+
+        $(".extend li.depends").each(function(){
+            var classes = $(this).attr("class").split(" ")
+            classes.shift() // Remove the module's safename class
+
+            classes.remove(["conflict",
+                            "depends",
+                            "missing_dependency",
+                            /depended_by_(.+)/,
+                            /needs_(.+)/,
+                            /conflict_(.+)/,
+                            /ui-draggable(-dragging)?/])
+
+            var gradients = []
+
+            for (i = 0; i < classes.length; i++) {
+                var depend = classes[i].replace("depends_", "module_")
+
+                if (dependency_displayed[$(this).attr("id")+" :: "+depend])
+                    continue
+
+                canvas.fillStyle = "#e4e3fb"
+                canvas.lineWidth = 3
+
+                var this_status = $(this).parent().parent().attr("class").split(" ")[0] + "d"
+                var depend_status = $("#"+depend).parent().parent().attr("class").split(" ")[0] + "d"
+
+                if (depend_status != this_status) {
+                    var line_from_x = (depend_status == "disabled") ? $("#"+depend).offset().left : $("#"+depend).offset().left + $("#"+depend).outerWidth()
+                    var line_from_y = $("#"+depend).offset().top + 12
+
+                    var line_to_x = (depend_status == "enabled") ? $(this).offset().left : $(this).offset().left + $(this).outerWidth()
+                    var line_to_y   = $(this).offset().top + 12
+                    var height = line_to_y - line_from_y
+                    var width = line_to_x - line_from_x
+
+                    if (height <= 45)
+                        gradients[i] = canvas.createLinearGradient(line_from_x, 0, line_from_x + width, 0)
+                    else
+                        gradients[i] = canvas.createLinearGradient(0, line_from_y, 0, line_from_y + height)
+
+                    gradients[i].addColorStop(0, '#0052cc')
+                    gradients[i].addColorStop(1, '#0096ff')
+
+                    canvas.strokeStyle = gradients[i]
+
+                    // Line
+                    canvas.moveTo(line_from_x, line_from_y)
+                    canvas.lineTo(line_to_x, line_to_y)
+                    canvas.stroke()
+                } else if (depend_status == "disabled") {
+                    var line_from_x = $("#"+depend).offset().left + $("#"+depend).outerWidth()
+                    var line_from_y = $("#"+depend).offset().top + 12
+                    var line_to_x   = $(this).offset().left + $(this).outerWidth()
+                    var line_to_y   = $(this).offset().top + 12
+                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
+                    var height = line_to_y - line_from_y
+                    var curve = line_from_x + 25
+
+                    gradients[i] = canvas.createLinearGradient(0, line_from_y, 0, line_from_y + height)
+                    gradients[i].addColorStop(0, '#0052cc')
+                    gradients[i].addColorStop(1, '#0096ff')
+
+                    canvas.strokeStyle = gradients[i]
+
+                    // Line
+                    canvas.beginPath()
+                    canvas.moveTo(line_from_x, line_from_y)
+                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
+                    canvas.stroke()
+                } else if (depend_status == "enabled") {
+                    var line_from_x = $("#"+depend).offset().left
+                    var line_from_y = $("#"+depend).offset().top + 12
+                    var line_to_x   = $(this).offset().left
+                    var line_to_y   = $(this).offset().top + 12
+                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
+                    var height = line_to_y - line_from_y
+                    var curve = line_from_x - 25
+
+                    gradients[i] = canvas.createLinearGradient(0, line_from_y, 0, line_from_y + height)
+                    gradients[i].addColorStop(0, '#0052cc')
+                    gradients[i].addColorStop(1, '#0096ff')
+
+                    canvas.strokeStyle = gradients[i]
+
+                    // Line
+                    canvas.beginPath()
+                    canvas.moveTo(line_from_x, line_from_y)
+                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
+                    canvas.stroke()
+                }
+
+                // Beginning circle
+                canvas.beginPath()
+                canvas.arc(line_from_x, line_from_y, 5, 0, Math.PI * 2, false)
+                canvas.fill()
+                canvas.stroke()
+
+                // Ending circle
+                canvas.beginPath()
+                canvas.arc(line_to_x, line_to_y, 5, 0, Math.PI * 2, false)
+                canvas.fill()
+                canvas.stroke()
+
+                dependency_displayed[depend+" :: "+$(this).attr("id")] = true
+            }
+        })
+
+        return true
+    }
+}
+
+<!-- --></script>

--- a/admin/themes/default/layout.twig
+++ b/admin/themes/default/layout.twig
@@ -12,6 +12,7 @@
         <script src="$site.chyrp_url/includes/lib/gz.php?file=plugins.js" type="text/javascript" charset="utf-8"></script>
         <script src="$site.chyrp_url/includes/lib/gz.php?file=redactor/redactor.min.js" type="text/javascript" charset="utf-8"></script>
         <script src="$site.chyrp_url/includes/admin.js.php?action=$route.action" type="text/javascript" charset="utf-8"></script>
+        <script src="$theme_url/javascript.php?action=$route.action" type="text/javascript" charset="utf-8"></script>
 ${ trigger.call("admin_head") }
     </head>
     <body>

--- a/feathers/audio/audio.php
+++ b/feathers/audio/audio.php
@@ -32,6 +32,12 @@
             $this->respondTo("admin_write_post", "swfupload");
             $this->respondTo("admin_edit_post", "swfupload");
             $this->respondTo("post_options", "add_option");
+            $this->respondTo("scripts", "add_jplayer_script");
+        }
+
+        public function add_jplayer_script($scripts) {
+            $scripts[] = Config::current()->chyrp_url."/feathers/audio/jplayer/jquery.jplayer.js";
+            return $scripts;
         }
 
         public function swfupload($admin, $post = null) {
@@ -200,7 +206,6 @@
             if (!file_exists(THEME_DIR."/stylesheets/jplayer.css"))
                 $player.= "\n\t".'<link href="'.$config->chyrp_url.'/feathers/audio/skin/blue.monday.hd/jplayer.blue.monday.hd.css" rel="stylesheet" type="text/css" />';
 
-            $player.= "\n\t".'<script src="'.$config->chyrp_url.'/feathers/audio/jplayer/jquery.jplayer.js" type="text/javascript"></script>';
             $player.= "\n\t".'<script>';
             $player.= "\n\t".'$(function(){';
             $player.= "\n\t\t".'$("#jquery_jplayer_'.$post->id.'").jPlayer({';

--- a/feathers/audio/audio.php
+++ b/feathers/audio/audio.php
@@ -202,7 +202,7 @@
 
             $player.= "\n\t".'<script src="'.$config->chyrp_url.'/feathers/audio/jplayer/jquery.jplayer.js" type="text/javascript"></script>';
             $player.= "\n\t".'<script>';
-            $player.= "\n\t".'$(document).ready(function(){';
+            $player.= "\n\t".'$(function(){';
             $player.= "\n\t\t".'$("#jquery_jplayer_'.$post->id.'").jPlayer({';
             $player.= "\n\t\t\t".'ready: function() {';
             $player.= "\n\t\t\t\t".'$(this).jPlayer("setMedia", {';

--- a/feathers/audio/audio.php
+++ b/feathers/audio/audio.php
@@ -197,7 +197,9 @@
             $player.= "\n\t\t".'</div>';
             $player.= "\n\t".'</div>';
 
-            $player.= "\n\t".'<link href="'.$config->chyrp_url.'/feathers/audio/skin/blue.monday.hd/jplayer.blue.monday.hd.css" rel="stylesheet" type="text/css" />';
+            if (!file_exists(THEME_DIR."/stylesheets/jplayer.css"))
+                $player.= "\n\t".'<link href="'.$config->chyrp_url.'/feathers/audio/skin/blue.monday.hd/jplayer.blue.monday.hd.css" rel="stylesheet" type="text/css" />';
+
             $player.= "\n\t".'<script src="'.$config->chyrp_url.'/feathers/audio/jplayer/jquery.jplayer.js" type="text/javascript"></script>';
             $player.= "\n\t".'<script>';
             $player.= "\n\t".'$(document).ready(function(){';

--- a/feathers/audio/audio.php
+++ b/feathers/audio/audio.php
@@ -170,7 +170,7 @@
             $player = "\n\t".'<div id="jquery_jplayer_'.$post->id.'" class="jp-jplayer"></div>';
             $player.= "\n\t".'<div id="jp_container_'.$post->id.'" class="jp-audio">';
             $player.= "\n\t\t".'<div class="jp-type-single">';
-            $player.= "\n\t\t\t".'<div id="jp-gui'.$post->id.'" class="jp-gui jp-interface" style="display:none;">';
+            $player.= "\n\t\t\t".'<div class="jp-gui jp-interface" style="display:none;">';
             $player.= "\n\t\t\t\t".'<ul class="jp-controls">';
             $player.= "\n\t\t\t\t\t".'<li><a href="javascript:;" class="jp-play" tabindex="1">play</a></li>';
             $player.= "\n\t\t\t\t\t".'<li><a href="javascript:;" class="jp-pause" tabindex="1">pause</a></li>';

--- a/feathers/audio/audio.php
+++ b/feathers/audio/audio.php
@@ -170,7 +170,7 @@
             $player = "\n\t".'<div id="jquery_jplayer_'.$post->id.'" class="jp-jplayer"></div>';
             $player.= "\n\t".'<div id="jp_container_'.$post->id.'" class="jp-audio">';
             $player.= "\n\t\t".'<div class="jp-type-single">';
-            $player.= "\n\t\t\t".'<div class="jp-gui jp-interface">';
+            $player.= "\n\t\t\t".'<div id="jp-gui'.$post->id.'" class="jp-gui jp-interface" style="display:none;">';
             $player.= "\n\t\t\t\t".'<ul class="jp-controls">';
             $player.= "\n\t\t\t\t\t".'<li><a href="javascript:;" class="jp-play" tabindex="1">play</a></li>';
             $player.= "\n\t\t\t\t\t".'<li><a href="javascript:;" class="jp-pause" tabindex="1">pause</a></li>';
@@ -200,6 +200,12 @@
             $player.= "\n\t\t\t\t".'<span>Update Required</span>';
             $player.= "\n\t\t\t\t".'To play the media you will need to either update your browser to a recent version or update your <a href="http://get.adobe.com/flashplayer/" target="_blank">Flash plugin</a>.';
             $player.= "\n\t\t\t".'</div>';
+            $player.= "\n\t\t\t".'<noscript>';
+            $player.= "\n\t\t\t\t".'<div class="jp-no-solution" style="display:block;">';
+            $player.= "\n\t\t\t\t\t".'<span>JavaScript Required</span>';
+            $player.= "\n\t\t\t\t\t".'To play <a href="'.uploaded($post->filename).'" type="'.$this->audio_type($post->filename).'">'.truncate(strip_tags($post->description)).'</a> you must enable JavaScript.';
+            $player.= "\n\t\t\t\t".'</div>';
+            $player.= "\n\t\t\t".'</noscript>';
             $player.= "\n\t\t".'</div>';
             $player.= "\n\t".'</div>';
 

--- a/includes/admin.js.php
+++ b/includes/admin.js.php
@@ -6,6 +6,12 @@
     $route = Route::current(MainController::current());
 ?>
 <!-- --><script>
+var Route = {
+    action: "<?php echo $_GET['action']; ?>"
+}
+
+var site_url = "<?php echo $config->chyrp_url; ?>"
+
 $(function(){
     // Scan AJAX responses for errors.
     $(document).ajaxComplete(function(event, request){
@@ -60,20 +66,14 @@ $(function(){
     // Checkbox toggling.
     togglers()
 
-    if (/(edit|write)_/.test(Route.action))
-        Write.init()
+    // Core admin behaviour
+    Admin.init()
 
     if (Route.action == "delete_group")
         $("form.confirm").submit(function(){
             if (!confirm("<?php echo __("You are a member of this group. Are you sure you want to delete it?"); ?>"))
                 return false
         })
-
-    if (Route.action == "manage_pages")
-        Manage.pages.init()
-
-    if (Route.action == "modules" || Route.action == "feathers")
-        Extend.init()
 
     // Remove things that only exist for JS-disabled users.
     $(".js_disabled").remove()
@@ -123,7 +123,6 @@ function togglers() {
         document.getElementById("toggle").checked = action_all_checked
     })
 
-
     if ($("#toggler").size())
         document.getElementById("toggle").checked = all_checked
 
@@ -135,19 +134,10 @@ function togglers() {
     })
 }
 
-var Route = {
-    action: "<?php echo $_GET['action']; ?>"
-}
-
-var site_url = "<?php echo $config->chyrp_url; ?>"
-
-var Write = {
+var Admin = {
     init: function(){
-        this.bookmarklet_link()
-        this.auto_expand_fields()
-
-        if (!$.browser.msie)
-            this.sortable_feathers()
+        if (/(write)_/.test(Route.action))
+            this.bookmarklet_link()
 
         this.prepare_previewer()
         this.more_options()
@@ -170,29 +160,6 @@ var Write = {
                           "e(s),u=f+p;a=function(){if(!w.open(u,\'t\',\'toolbar=0,resizable=1,status=1,width=450,"+
                           "height=430\'))l.href=u;};if(/Firefox/.test(navigator.userAgent))setTimeout(a,0);else%20a();void(0)")
             .appendTo(".bookmarklet")
-    },
-    auto_expand_fields: function(){
-        $("input.text").expand()
-    },
-    sortable_feathers: function(){
-        // Make the Feathers sortable
-        $("#sub-nav").sortable({
-            axis: "x",
-            placeholder: "feathers_sort",
-            opacity: 0.8,
-            delay: 1,
-            revert: true,
-            cancel: "a.no_drag, a[href$=write_page]",
-            start: function(e, ui) {
-                $(ui.item).find("a").click(function(){ return false })
-                $(".feathers_sort").width($(ui.item).width() - 2)
-            },
-            update: function(e, ui){
-                $(ui.item).find("a").unbind("click")
-                $.post("<?php echo $config->chyrp_url; ?>/includes/ajax.php",
-                       "action=reorder_feathers&"+ $("#sub-nav").sortable("serialize"))
-            }
-        })
     },
     prepare_previewer: function() {
         if (!$(".preview_me").size())
@@ -269,475 +236,6 @@ var Write = {
             if (!confirm("<?php echo __("You are a member of this group. Are you sure the permissions are as you want them?"); ?>"))
                 return false
         })
-    }
-}
-
-var Manage = {
-    pages: {
-        init: function(){
-            Manage.pages.prepare_reordering()
-        },
-        parent_hash: function(){
-            var parent_hash = ""
-            $(".sort_pages li").each(function(){
-                var id = $(this).attr("id").replace(/page_list_/, "")
-                var parent = $(this).parent().parent() // this > #sort_pages > page_list_(id)
-                var parent_id = (/page_list_/.test(parent.attr("id"))) ? parent.attr("id").replace(/page_list_/, "") : 0
-                $(this).attr("parent", parent_id)
-                parent_hash += "&parent["+id+"]="+parent_id
-            })
-            return parent_hash
-        },
-        prepare_reordering: function(){
-            $(".sort_pages li div").css({
-                background: "#f9f9f9",
-                padding: ".15em .5em",
-                marginBottom: ".5em",
-                border: "1px solid #ddd",
-                cursor: "move"
-            })
-
-            $("ul.sort_pages").tree({
-                sortOn: "li",
-                dropOn: "li:not(.dragging) div",
-                hoverClass: "sort-hover",
-                done: function(){
-                    $("#content > form > ul.sort_pages").loader()
-                    $.post("<?php echo $config->chyrp_url; ?>/includes/ajax.php",
-                           "action=organize_pages&"+ $("ul.sort_pages").sortable("serialize") + Manage.pages.parent_hash(),
-                           function(){ $("#content > form > ul.sort_pages").loader(true) })
-                }
-            })
-        }
-    }
-}
-
-var Extend = {
-    init: function(){
-        this.prepare_info()
-        this.prepare_draggables()
-
-        if (Route.action != "modules")
-            return
-
-        this.draw_conflicts()
-        this.draw_dependencies()
-
-        $(window).resize(function(){
-            Extend.draw_conflicts()
-            Extend.draw_dependencies()
-        })
-    },
-    Drop: {
-        extension: {
-            classes: [],
-            name: null,
-            type: null
-        },
-        action: null,
-        previous: null,
-        pane: null,
-        confirmed: null
-    },
-    prepare_info: function(){
-        $(".description:not(.expanded)").wrap("<div></div>").parent().hide()
-        $(".info_link").click(function(){
-            $(this).parent().find(".description").parent().slideToggle("normal", Extend.redraw)
-            return false
-        })
-    },
-    prepare_draggables: function(){
-        $(".enable h2, .disable h2").append(" <span class=\"sub desktop\"><?php echo __("(drag)"); ?></span>")
-
-        $(".disable > ul > li:not(.missing_dependency), .enable > ul > li").draggable({
-            zIndex: 100,
-            cancel: "a",
-            revert: true
-        })
-
-        $(".enable > ul, .disable > ul").droppable({
-            accept: "ul.extend > li:not(.missing_dependency)",
-            tolerance: "pointer",
-            activeClass: "active",
-            hoverClass: "hover",
-            drop: Extend.handle_drop
-        })
-
-        $(".enable > ul > li, .disable > ul > li:not(.missing_dependency)").css("cursor", "move")
-
-        Extend.equalize_lists()
-
-        if ($(".feather").size())
-            <?php $tip = _f("(tip: drag the tabs on the <a href=\\\"%s\\\">write</a> page to reorder them)",
-                            array(url("/admin/?action=write"))); ?>
-            $(document.createElement("small")).html("<?php echo $tip; ?>").css({
-                position: "relative",
-                bottom: "-1em",
-                display: "block",
-                textAlign: "center"
-            }).appendTo(".tip_here")
-    },
-    handle_drop: function(ev, ui) {
-        var classes = $(this).parent().attr("class").split(" ")
-
-        Extend.Drop.pane = $(this)
-        Extend.Drop.action = classes[0]
-        Extend.Drop.previous = $(ui.draggable).parent().parent().attr("class").split(" ")[0]
-        Extend.Drop.extension.classes = $(ui.draggable).attr("class").split(" ")
-        Extend.Drop.extension.name = Extend.Drop.extension.classes[0]
-        Extend.Drop.extension.type = classes[1]
-
-        Extend.Drop.confirmed = false
-
-        if (Extend.Drop.previous == Extend.Drop.action)
-            return
-
-        $.post("<?php echo $config->chyrp_url; ?>/includes/ajax.php", {
-            action: "check_confirm",
-            check: Extend.Drop.extension.name,
-            type: Extend.Drop.extension.type
-        }, function(data){
-            if (data != "" && Extend.Drop.action == "disable")
-                Extend.Drop.confirmed = (confirm(data)) ? 1 : 0
-
-            $.ajax({
-                type: "post",
-                dataType: "json",
-                url: "<?php echo $config->chyrp_url; ?>/includes/ajax.php",
-                data: {
-                    action: Extend.Drop.action + "_" + Extend.Drop.extension.type,
-                    extension: Extend.Drop.extension.name,
-                    confirm: Extend.Drop.confirmed
-                },
-                beforeSend: function(){ Extend.Drop.pane.loader() },
-                success: Extend.finish_drop,
-                error: function() {
-                    if (Extend.Drop.action == "enable")
-                        alert("<?php echo __("There was an error enabling the extension."); ?>");
-                    else
-                        alert("<?php echo __("There was an error disabling the extension."); ?>");
-
-                    Extend.Drop.pane.loader(true)
-
-                    $(ui.draggable).css({ left: 0, right: 0, top: 0, bottom: 0 }).appendTo($(".disable ul"))
-
-                    Extend.redraw()
-                }
-            })
-        }, "text")
-
-        $(ui.draggable).css({ left: 0, right: 0, top: 0, bottom: 0 }).appendTo(this)
-
-        Extend.redraw()
-
-        return true
-    },
-    finish_drop: function(json){
-        if (Extend.Drop.action == "enable") {
-            var dependees = Extend.Drop.extension.classes.find(/depended_by_(.+)/)
-            for (i = 0; i < dependees.length; i++) {
-                var dependee = dependees[i].replace("depended_by", "module")
-
-                // The module depending on this one no longer "needs" it
-                $("#"+ dependee).removeClass("needs_"+ Extend.Drop.extension.name)
-
-                // Remove from the dependee's dependency list
-                $("#"+ dependee +" .dependencies_list ."+ Extend.Drop.extension.name).hide()
-
-                if ($("#"+ dependee).attr("class").split(" ").find(/needs_(.+)/).length == 0)
-                    $("#"+ dependee).find(".description").parent().hide().end().end()
-                                    .draggable({
-                                        zIndex: 100,
-                                        cancel: "a",
-                                        revert: true
-                                    })
-                                    .css("cursor", "move")
-            }
-        } else if ($(".depends_"+ Extend.Drop.extension.name).size()) {
-            $(".depends_"+ Extend.Drop.extension.name).find(".description").parent().show()
-            $(".depends_"+ Extend.Drop.extension.name)
-                .find(".dependencies_list")
-                .append($(document.createElement("li")).text(Extend.Drop.extension.name).addClass(Extend.Drop.extension.name))
-                .show()
-                .end()
-                .find(".dependencies_message")
-                .show()
-                .end()
-                .addClass("needs_"+ Extend.Drop.extension.name)
-        }
-
-        Extend.Drop.pane.loader(true)
-        $(json.notifications).each(function(){
-            if (this == "") return
-            alert(this.replace(/<([^>]+)>\n?/gm, ""))
-        })
-
-        Extend.redraw()
-    },
-    equalize_lists: function(){
-        $("ul.extend").height("auto")
-        $("ul.extend").each(function(){
-            if ($(".enable ul.extend").height() > $(this).height())
-                $(this).css('min-height', $(".enable ul.extend").height())
-
-            if ($(".disable ul.extend").height() > $(this).height())
-                $(this).css('min-height', $(".disable ul.extend").height())
-        })
-    },
-    redraw: function(){
-        Extend.equalize_lists()
-        Extend.draw_conflicts()
-        Extend.draw_dependencies()
-    },
-    draw_conflicts: function(){
-        if (!$.support.boxModel ||
-            Route.action != "modules" ||
-            (!$(".extend li.conflict").size()))
-            return false
-
-        $("#conflicts_canvas").remove()
-
-        $("#header, #welcome, #sub-nav, #content a.button, .extend li, #footer, h1, h2").css({
-            position: "relative",
-            zIndex: 2
-        })
-        $("#header ul li a").css({
-            position: "relative",
-            zIndex: 3
-        })
-
-        $(document.createElement("canvas")).attr("id", "conflicts_canvas").prependTo("body")
-        $("#conflicts_canvas").css({
-            position: "absolute",
-            top: 0,
-            bottom: 0,
-            zIndex: 1
-        }).attr({ width: $(document).width(), height: $(document).height() })
-
-        var canvas = document.getElementById("conflicts_canvas").getContext("2d")
-        var conflict_displayed = []
-
-        $(".extend li.conflict").each(function(){
-            var classes = $(this).attr("class").split(" ")
-            classes.shift() // Remove the module's safename class
-
-            classes.remove(["conflict",
-                            "depends",
-                            "missing_dependency",
-                            /depended_by_(.+)/,
-                            /needs_(.+)/,
-                            /depends_(.+)/,
-                            /ui-draggable(-dragging)?/])
-
-            for (i = 0; i < classes.length; i++) {
-                var conflict = classes[i].replace("conflict_", "module_")
-
-                if (conflict_displayed[$(this).attr("id")+" :: "+conflict])
-                    continue
-
-                canvas.strokeStyle = "#ef4646"
-                canvas.fillStyle = "#fbe3e4"
-                canvas.lineWidth = 3
-
-                var this_status = $(this).parent().parent().attr("class").split(" ")[0] + "d"
-                var conflict_status = $("#"+conflict).parent().parent().attr("class").split(" ")[0] + "d"
-
-                if (conflict_status != this_status) {
-                    var line_from_x = (conflict_status == "disabled") ?
-                                      $("#"+conflict).offset().left :
-                                      $("#"+conflict).offset().left + $("#"+conflict).outerWidth()
-                    var line_from_y = $("#"+conflict).offset().top + 12
-                    var line_to_x = (conflict_status == "enabled") ?
-                                    $(this).offset().left :
-                                    $(this).offset().left + $(this).outerWidth()
-                    var line_to_y   = $(this).offset().top + 12
-
-                    // Line
-                    canvas.moveTo(line_from_x, line_from_y)
-                    canvas.lineTo(line_to_x, line_to_y)
-                    canvas.stroke()
-                } else if (conflict_status == "disabled") {
-                    var line_from_x = $("#"+conflict).offset().left
-                    var line_from_y = $("#"+conflict).offset().top + 12
-                    var line_to_x   = $(this).offset().left
-                    var line_to_y   = $(this).offset().top + 12
-                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
-                    var curve = line_from_x - 25
-
-                    // Line
-                    canvas.beginPath()
-                    canvas.moveTo(line_from_x, line_from_y)
-                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
-                    canvas.stroke()
-                } else if (conflict_status == "enabled") {
-                    var line_from_x = $("#"+conflict).offset().left + $("#"+conflict).outerWidth()
-                    var line_from_y = $("#"+conflict).offset().top + 12
-                    var line_to_x   = $(this).offset().left + $(this).outerWidth()
-                    var line_to_y   = $(this).offset().top + 12
-                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
-                    var curve = line_from_x + 25
-
-                    // Line
-                    canvas.beginPath()
-                    canvas.moveTo(line_from_x, line_from_y)
-                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
-                    canvas.stroke()
-                }
-
-                // Beginning circle
-                canvas.beginPath()
-                canvas.arc(line_from_x, line_from_y, 5, 0, Math.PI * 2, false)
-                canvas.fill()
-                canvas.stroke()
-
-                // Ending circle
-                canvas.beginPath()
-                canvas.arc(line_to_x, line_to_y, 5, 0, Math.PI * 2, false)
-                canvas.fill()
-                canvas.stroke()
-
-                conflict_displayed[conflict+" :: "+$(this).attr("id")] = true
-            }
-        })
-
-        return true
-    },
-    draw_dependencies: function() {
-        if (!$.support.boxModel ||
-            Route.action != "modules" ||
-            (!$(".extend li.depends").size()))
-            return false
-
-        $("#depends_canvas").remove()
-
-        $("#header, #welcome, #sub-nav, #content a.button, .extend li, #footer, h1, h2").css({
-            position: "relative",
-            zIndex: 2
-        })
-        $("#header ul li a").css({
-            position: "relative",
-            zIndex: 3
-        })
-
-        $(document.createElement("canvas")).attr("id", "depends_canvas").prependTo("body")
-        $("#depends_canvas").css({
-            position: "absolute",
-            top: 0,
-            bottom: 0,
-            zIndex: 1
-        }).attr({ width: $(document).width(), height: $(document).height() })
-
-        var canvas = document.getElementById("depends_canvas").getContext("2d")
-        var dependency_displayed = []
-
-        $(".extend li.depends").each(function(){
-            var classes = $(this).attr("class").split(" ")
-            classes.shift() // Remove the module's safename class
-
-            classes.remove(["conflict",
-                            "depends",
-                            "missing_dependency",
-                            /depended_by_(.+)/,
-                            /needs_(.+)/,
-                            /conflict_(.+)/,
-                            /ui-draggable(-dragging)?/])
-
-            var gradients = []
-
-            for (i = 0; i < classes.length; i++) {
-                var depend = classes[i].replace("depends_", "module_")
-
-                if (dependency_displayed[$(this).attr("id")+" :: "+depend])
-                    continue
-
-                canvas.fillStyle = "#e4e3fb"
-                canvas.lineWidth = 3
-
-                var this_status = $(this).parent().parent().attr("class").split(" ")[0] + "d"
-                var depend_status = $("#"+depend).parent().parent().attr("class").split(" ")[0] + "d"
-
-                if (depend_status != this_status) {
-                    var line_from_x = (depend_status == "disabled") ? $("#"+depend).offset().left : $("#"+depend).offset().left + $("#"+depend).outerWidth()
-                    var line_from_y = $("#"+depend).offset().top + 12
-
-                    var line_to_x = (depend_status == "enabled") ? $(this).offset().left : $(this).offset().left + $(this).outerWidth()
-                    var line_to_y   = $(this).offset().top + 12
-                    var height = line_to_y - line_from_y
-                    var width = line_to_x - line_from_x
-
-                    if (height <= 45)
-                        gradients[i] = canvas.createLinearGradient(line_from_x, 0, line_from_x + width, 0)
-                    else
-                        gradients[i] = canvas.createLinearGradient(0, line_from_y, 0, line_from_y + height)
-
-                    gradients[i].addColorStop(0, '#0052cc')
-                    gradients[i].addColorStop(1, '#0096ff')
-
-                    canvas.strokeStyle = gradients[i]
-
-                    // Line
-                    canvas.moveTo(line_from_x, line_from_y)
-                    canvas.lineTo(line_to_x, line_to_y)
-                    canvas.stroke()
-                } else if (depend_status == "disabled") {
-                    var line_from_x = $("#"+depend).offset().left + $("#"+depend).outerWidth()
-                    var line_from_y = $("#"+depend).offset().top + 12
-                    var line_to_x   = $(this).offset().left + $(this).outerWidth()
-                    var line_to_y   = $(this).offset().top + 12
-                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
-                    var height = line_to_y - line_from_y
-                    var curve = line_from_x + 25
-
-                    gradients[i] = canvas.createLinearGradient(0, line_from_y, 0, line_from_y + height)
-                    gradients[i].addColorStop(0, '#0052cc')
-                    gradients[i].addColorStop(1, '#0096ff')
-
-                    canvas.strokeStyle = gradients[i]
-
-                    // Line
-                    canvas.beginPath()
-                    canvas.moveTo(line_from_x, line_from_y)
-                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
-                    canvas.stroke()
-                } else if (depend_status == "enabled") {
-                    var line_from_x = $("#"+depend).offset().left
-                    var line_from_y = $("#"+depend).offset().top + 12
-                    var line_to_x   = $(this).offset().left
-                    var line_to_y   = $(this).offset().top + 12
-                    var median = line_from_y + ((line_to_y - line_from_y) / 2)
-                    var height = line_to_y - line_from_y
-                    var curve = line_from_x - 25
-
-                    gradients[i] = canvas.createLinearGradient(0, line_from_y, 0, line_from_y + height)
-                    gradients[i].addColorStop(0, '#0052cc')
-                    gradients[i].addColorStop(1, '#0096ff')
-
-                    canvas.strokeStyle = gradients[i]
-
-                    // Line
-                    canvas.beginPath()
-                    canvas.moveTo(line_from_x, line_from_y)
-                    canvas.quadraticCurveTo(curve, median, line_to_x, line_to_y)
-                    canvas.stroke()
-                }
-
-                // Beginning circle
-                canvas.beginPath()
-                canvas.arc(line_from_x, line_from_y, 5, 0, Math.PI * 2, false)
-                canvas.fill()
-                canvas.stroke()
-
-                // Ending circle
-                canvas.beginPath()
-                canvas.arc(line_to_x, line_to_y, 5, 0, Math.PI * 2, false)
-                canvas.fill()
-                canvas.stroke()
-
-                dependency_displayed[depend+" :: "+$(this).attr("id")] = true
-            }
-        })
-
-        return true
     }
 }
 

--- a/modules/cascade/javascript.php
+++ b/modules/cascade/javascript.php
@@ -45,6 +45,7 @@
                             if ( ajax_page_link ) {
                                 // We found another page to load
                                 $("#next_page_page").replaceWith(ajax_page_link);
+                                if ( !ChyrpAjaxScroll.auto ) $("#next_page_page").click(ChyrpAjaxScroll.fetch);
                                 ChyrpAjaxScroll.busy = false;
                             } else {
                                 // That's all Folks!

--- a/modules/cascade/javascript.php
+++ b/modules/cascade/javascript.php
@@ -38,11 +38,13 @@
                             $(data).filter('script').each(function(){
                                 $.globalEval( this.text || this.textContent || this.innerHTML || "" );
                             });
+                            // Update the page description
+                            $(".pages").last().replaceWith( $(data).find('.pages').last() );
                             // Search for the next page link
-                            var ajax_page_url = $(data).find("#next_page_page").last().attr('href');
-                            if ( ajax_page_url ) {
+                            var ajax_page_link = $(data).find("#next_page_page").last();
+                            if ( ajax_page_link ) {
                                 // We found another page to load
-                                $("#next_page_page").attr('href', ajax_page_url);
+                                $("#next_page_page").replaceWith(ajax_page_link);
                                 ChyrpAjaxScroll.busy = false;
                             } else {
                                 // That's all Folks!

--- a/modules/cascade/javascript.php
+++ b/modules/cascade/javascript.php
@@ -32,12 +32,20 @@
                     if ( next_page_url && last_post.length ) {
                         $.get(next_page_url, function(data){
                             if ( !!history.replaceState ) history.replaceState(ChyrpAjaxScroll.state, '', next_page_url );
+                            // Insert new posts
                             $(".post").last().after($(data).find(".post"));
+                            // Find and execute scripts
+                            $(data).filter('script').each(function(){
+                                $.globalEval(this.text || this.textContent || this.innerHTML || '');
+                            });
+                            // Search for next_page_page
                             var ajax_page_url = $(data).find("#next_page_page").last().attr('href');
                             if ( ajax_page_url ) {
+                                // We found another page to load
                                 $("#next_page_page").attr('href', ajax_page_url);
                                 ChyrpAjaxScroll.busy = false;
                             } else {
+                                // That's all Folks!
                                 $("#next_page_page").fadeOut('fast');
                             }
                         }).fail( function() { ChyrpAjaxScroll.fail = true });

--- a/modules/cascade/javascript.php
+++ b/modules/cascade/javascript.php
@@ -34,14 +34,11 @@
                             if ( !!history.replaceState ) history.replaceState(ChyrpAjaxScroll.state, '', next_page_url );
                             // Insert new posts
                             $(".post").last().after($(data).find(".post"));
-                            // Find and execute scripts
+                            // Execute inline scripts
                             $(data).filter('script').each(function(){
-                                if ( this.src )
-                                    $.ajax({ url: this.src, async: false, dataType: "script" });
-                                else
-                                    $.globalEval( this.text || this.textContent || this.innerHTML || "" );
+                                $.globalEval( this.text || this.textContent || this.innerHTML || "" );
                             });
-                            // Search for next_page_page
+                            // Search for the next page link
                             var ajax_page_url = $(data).find("#next_page_page").last().attr('href');
                             if ( ajax_page_url ) {
                                 // We found another page to load

--- a/modules/cascade/javascript.php
+++ b/modules/cascade/javascript.php
@@ -36,7 +36,10 @@
                             $(".post").last().after($(data).find(".post"));
                             // Find and execute scripts
                             $(data).filter('script').each(function(){
-                                $.globalEval(this.text || this.textContent || this.innerHTML || '');
+                                if ( this.src )
+                                    $.ajax({ url: this.src, async: false, dataType: "script" });
+                                else
+                                    $.globalEval( this.text || this.textContent || this.innerHTML || "" );
                             });
                             // Search for next_page_page
                             var ajax_page_url = $(data).find("#next_page_page").last().attr('href');

--- a/themes/firecrest/pages/archive.twig
+++ b/themes/firecrest/pages/archive.twig
@@ -16,7 +16,7 @@
                     {% endif %}
                     <ul>
                         {% for post in archive.posts %}
-                        <li>${ post.created_at | strftime("%d" | translate) }: <a href="$post.url">${ post.title | normalize | truncate(70) }</a></li>
+                        <li class="post">${ post.created_at | strftime("%d" | translate) }: <a href="$post.url">${ post.title | normalize | truncate(70) }</a></li>
                         {% endfor %}
                     </ul>
                     <br />
@@ -32,7 +32,7 @@
                     {% endif %}
                     <ul>
                         {% for post in posts.paginated %}
-                        <li>${ post.created_at | strftime("%d" | translate) }: <a href="$post.url">${ post.title | normalize | truncate(70) }</a></li>
+                        <li class="post">${ post.created_at | strftime("%d" | translate) }: <a href="$post.url">${ post.title | normalize | truncate(70) }</a></li>
                         {% endfor %}
                     </ul>
 {% endif %}


### PR DESCRIPTION
# Admin refactoring

Separated core admin behaviour and theme-specific stuff into two JS files. This will makes things easier for theme authors if they want to implement different behaviours for the admin pages.
# Cascade module update

Now scans for inline JS in the fetched pages, necessary for Audio feather and any other feathers that do inline JS stuff to initialize themselves. Also improved the commenting a little bit, so it's clear what is going on during the fetch. Incorporated contribution from @onmoon to update Firecrest's page descriptions ("page X of X") and added updating of the "next page" link in its entirety.
# Audio feather enhancements

jPlayer script has been taken out of the feather output. Instead the feather is now responding to the “scripts” trigger and adding the jPlayer script. This avoids the script from being loaded in duplicate when there is more than one audio feather on the page and it also makes Audio feather compatible with Cascade module (Cascade will not execute linked scripts).

Audio feather now also searches for a jPlayer css file in the active theme's stylesheets folder. This allows theme authors to reskin jPlayer. If no jPlayer css file is found in the active theme, the default “Blue Monday” css is linked.

Last but not least, noscript fallback has been added to the Audio feather. If JS is disabled, the jPlayer GUI is not shown and instead an error message is shown, including a direct link to the audio file. If JS is enabled, the noscript tags are ignored and jPlayer unhides its GUI as part of its init procedure.
