### PR TITLE
Refactored Likes module

### DIFF
--- a/modules/likes/javascript.php
+++ b/modules/likes/javascript.php
@@ -8,6 +8,9 @@
         var likes = {};
         likes.action = "like";
         likes.didPrevFinish = true;
+        likes.init = function() {
+            $("div.likes a").css("display", "inline"); // Enable liking
+        }
         likes.makeCall = function(post_id, callback, isUnlike) {
             if (!this.didPrevFinish) return false;
             if (isUnlike == true) this.action = "unlike"; else this.action = "like";
@@ -26,51 +29,46 @@
                         callback(response);
                     }
                     else {
-                        likes.log("unsuccessful request, response from server:"+ response)
+                        likes.log("unsuccessful request, response from server:"+ response);
                     }
                 },
                 error:function (xhr, ajaxOptions, thrownError) {
-                    likes.log('error in AJAX request.')
-                    likes.log('xhrObj:'+xhr)
-                    likes.log('thrownError:'+thrownError)
-                    likes.log('ajaxOptions:'+ajaxOptions)
+                    likes.log('error in AJAX request.');
+                    likes.log('xhrObj:'+xhr);
+                    likes.log('thrownError:'+thrownError);
+                    likes.log('ajaxOptions:'+ajaxOptions);
                 },
                 complete:function() {
-                    this.didPrevFinish = true
+                    this.didPrevFinish = true;
                 },
                 dataType: "json",
                 cache: false
             })
         }
+        likes.toggle = function(post_id) {
+            if ( $("#likes_post-"+post_id+" a.liked").length ) {
+                this.unlike(post_id);
+            } else {
+                this.like(post_id);
+            }
+        }
         likes.like = function(post_id) {
-            //likes.log("like click for post-"+post_id)
-            $("#likes_post-"+post_id+" a.like").fadeTo(500,.2)
             this.makeCall(post_id,function(response) {
-                var postDom = $("#likes_post-"+post_id)
-                postDom.children("span.text").html(response.likeText)
-                var thumbImg = postDom.children("a.like").children("img")
-                postDom.children("a.like").attr("title","").removeAttr("href").text("").addClass("liked").removeClass("like")
-                thumbImg.appendTo(postDom.children("a.liked").eq(0))
-                postDom.children("a.liked").fadeTo("500",.80)
-                postDom.find(".like").hide("fast")
-                //postDom.children("a.unlike").show("fast")
+                var postDom = $("#likes_post-"+post_id);
+                postDom.children("span.text").html(response.likeText);
+                postDom.children("a.like").removeClass("like").addClass("liked");
             }, false);
         }
         likes.unlike = function(post_id) {
-            //likes.log("unlike click for post-"+post_id)
-            $("#likes_post-"+post_id+" a.liked").fadeTo(500,.2)
             this.makeCall(post_id,function(response) {
-                var postDom = $("#likes_post-"+post_id)
-                postDom.children("span.text").html(response.likeText)
-                var thumbImg = postDom.children("a.liked").children("img")
-                postDom.children("a.liked").attr("href","javascript:likes.like("+post_id+")").text("").addClass("like").removeClass("liked").fadeTo("500",1)
-                thumbImg.appendTo(postDom.children("a.like").eq(0))
-                postDom.children("a.liked").hide("fast")
-                postDom.find(".like").show("fast")
-            }, true)
+                var postDom = $("#likes_post-"+post_id);
+                postDom.children("span.text").html(response.likeText);
+                postDom.children("a.liked").removeClass("liked").addClass("like");
+            }, true);
         }
         likes.log = function(obj){
             if(typeof console != "undefined")console.log(obj);
         }
+        $(document).ready(likes.init);
 <?php Trigger::current()->call("likes_javascript"); ?>
 <!-- --></script>

--- a/modules/likes/likes.php
+++ b/modules/likes/likes.php
@@ -197,11 +197,12 @@
             $returnStr = "<div class='likes' id='likes_post-$post->id'>";
 
             if (!$hasPersonLiked) {
-                $returnStr.= "<a class='like' href=\"javascript:likes.like($post->id);\" title='".
-                    ($like->total_count ? $likeSetting["likeText"][6] : "")."' >";
-                $returnStr.= "<img src=\"".$likeSetting["likeImage"]."\" alt='Like Post-$post->id' />";
-                if ($likeSetting["likeWithText"]) # $this->text_default[6] = "Like";
-                    $returnStr.= "(".$likeSetting["likeText"][6].") ";
+                $returnStr.= "<a class='like' href=\"javascript:likes.toggle($post->id);\">";
+                $returnStr.= "<img src=\"".$likeSetting["likeImage"]."\" alt='".$likeSetting["likeText"][6]."' /> ";
+                if ($likeSetting["likeWithText"]) {
+                    $returnStr.= "<span class='like'>(".$likeSetting["likeText"][6].")</span> "; # $this->text_default[6] = "Like!"
+                    $returnStr.= "<span class='unlike'>(".$likeSetting["likeText"][7].")</span> "; # $this->text_default[7] = "Unlike!"
+                }
                 $returnStr.= "</a><span class='text'>";
                 if ($like->total_count == 0)
                     # $this->text_default[3] = "Be the first to like.";
@@ -214,11 +215,16 @@
                     $returnStr.= $like->getText($like->total_count, $likeSetting["likeText"][5]);
                 $returnStr.= "</span>";
             } else {
-                # $this->text_default[7] = "Unlike";
-                if ($likeSetting["likeWithText"] and $visitor->group->can("unlike_post") and $hasPersonLiked)
-                    $returnStr.= "<a class='liked' href=\"javascript:likes.unlike($post->id);\"><img src=\"".$likeSetting["likeImage"]."\" alt='Like Post-$post->id' />(".$likeSetting["likeText"][7].") </a><span class='text'>";
+                if ($visitor->group->can("unlike_post") and $hasPersonLiked)
+                    $returnStr.= "<a class='liked' href=\"javascript:likes.toggle($post->id);\">";
                 else
-                    $returnStr.= "<a class='liked'><img src=\"".$likeSetting["likeImage"]."\" alt='Like Post-$post->id' /></a><span class='text'>";
+                    $returnStr.= "<a class='liked'>";
+                $returnStr.= "<img src=\"".$likeSetting["likeImage"]."\" alt='".$likeSetting["likeText"][7]."' /> ";
+                if ($likeSetting["likeWithText"]) {
+                    $returnStr.= "<span class='like'>(".$likeSetting["likeText"][6].")</span> "; # $this->text_default[6] = "Like!"
+                    $returnStr.= "<span class='unlike'>(".$likeSetting["likeText"][7].")</span> "; # $this->text_default[7] = "Unlike!"
+                }
+                $returnStr.= "</a><span class='text'>";
                 if ($like->total_count == 1)
                     # $this->text_default[0] = "You like this post.";
                     $returnStr.= $like->getText($like->total_count, $likeSetting["likeText"][0]);

--- a/modules/likes/style.css
+++ b/modules/likes/style.css
@@ -1,11 +1,16 @@
-.likes { position: relative; display: inline; }
-.likes span.text{ }
-.likes a.like img, .likes a.liked img {
-    vertical-align: middle;
-    opacity: .8;
-    filter: alpha(opacity = 80);
-    margin: -2px 5px 0 0!important;
+div.likes {
+	position: relative;
+	display: inline;
 }
-.likes a.like img:hover { opacity: 1; filter: alpha(opacity = 100); }
-.likes a.like:hover { text-decoration: none; }
-.likes div.unlike { display: none; }
+div.likes a {
+	display: none;
+}
+div.likes a.like img, div.likes a.liked img {
+    vertical-align: middle;
+}
+div.likes a.like span.unlike {
+	display: none;
+}
+div.likes a.liked span.like {
+	display: none;
+}


### PR DESCRIPTION
Modified `get_likes()` function to output more predictable HTML structure, and rationalised JavaScript a lot – dropped brute force DOM manipulation in favour of simple class substitution. It's now a lot easier to see what the  JS and PHP are doing.
### Changed behaviours:
1. Posts can now be liked and unliked multiple times without requiring a page refresh.
2. Like message is now displayed without clickable image/text for non-JS clients – `init()` function enables liking on page load for JS-enabled clients.
3. Both “(Like)” and “(Unlike)” texts are always present in the DOM if “like with text” setting is enabled – which one to show is now handled entirely with a couple of CSS rules.
4. Removed some presentation-related CSS that shouldn’t be forced by the module; link opacity, underline etc. should be controlled by the blog theme.
5. Tightened up CSS targeting: the module knows it's outputting a div, so we should be targeting "div.likes".
