### PR TITLE
WordPress import: fixed import and enabled post types

### DIFF
--- a/admin/themes/default/pages/import.twig
+++ b/admin/themes/default/pages/import.twig
@@ -62,7 +62,9 @@
                             ${ "Usually something like <code>http://example.com/wp-content/uploads/</code>." | translate }
                         </small>
                     </p>
-
+                    
+                    ${ trigger.call("import_wordpress_enhancement") }
+                    
                     <p class="buttons">
                         <button type="submit" class="yay"><img src="$theme_url/images/icons/success.svg" alt="success" />${ "Import" | translate }</button>
                     </p>

--- a/includes/controller/Admin.php
+++ b/includes/controller/Admin.php
@@ -1249,7 +1249,7 @@
 
             $xml = simplexml_load_string($sane_xml, "SimpleXMLElement", LIBXML_NOCDATA);
 
-            if (!$xml or !substr_count($xml->channel->generator, "wordpress.org"))
+            if (!$xml or !(substr_count($xml->channel->generator, "wordpress.org") || substr_count($xml->channel->generator, "wordpress.com")))
                 Flash::warning(__("File does not seem to be a valid WordPress export file, or could not be parsed. Please check your PHP error log."),
                                "/admin/?action=import");
 

--- a/includes/controller/Admin.php
+++ b/includes/controller/Admin.php
@@ -1256,17 +1256,20 @@
             foreach ($xml->channel->item as $item) {
                 $wordpress = $item->children("http://wordpress.org/export/1.2/");
                 $content   = $item->children("http://purl.org/rss/1.0/modules/content/");
-                if ($wordpress->status == "attachment" or $item->title == "zz_placeholder")
+                $contentencoded = $content->encoded;
+                if ($wordpress->post_type == "attachment" or $wordpress->status == "attachment" or $item->title == "zz_placeholder")
                     continue;
 
+                $media = array();
                 $regexp_url = preg_quote($_POST['media_url'], "/");
                 if (!empty($_POST['media_url']) and
                     preg_match_all("/{$regexp_url}([^\.\!,\?;\"\'<>\(\)\[\]\{\}\s\t ]+)\.([a-zA-Z0-9]+)/",
-                                   $content->encoded,
+                                   $contentencoded,
                                    $media))
-                    foreach ($media[0] as $matched_url) {
+                    $media_uris = array_unique($media[0]);
+                    foreach ($media_uris as $matched_url) {
                         $filename = upload_from_url($matched_url);
-                        $content->encoded = str_replace($matched_url, $config->url.$config->uploads_path.$filename, $content->encoded);
+                        $contentencoded = str_replace($matched_url, $config->url.$config->uploads_path.$filename, $contentencoded);
                     }
 
                 $clean = (isset($wordpress->post_name) && $wordpress->post_name != '') ? $wordpress->post_name : sanitize($item->title) ;
@@ -1286,7 +1289,7 @@
                     $data = array(
                                 "content" => array(
                                                 "title" => trim($item->title),
-                                                "body" => trim($content->encoded),
+                                                "body" => trim($contentencoded),
                                                 "imported_from" => "wordpress"
                                              ),
                                 "feather" => "text"

--- a/includes/controller/Admin.php
+++ b/includes/controller/Admin.php
@@ -1257,21 +1257,29 @@
                 $wordpress = $item->children("http://wordpress.org/export/1.2/");
                 $content   = $item->children("http://purl.org/rss/1.0/modules/content/");
                 $contentencoded = $content->encoded;
-                if ($wordpress->post_type == "attachment" or $wordpress->status == "attachment" or $item->title == "zz_placeholder")
+                if ($wordpress->post_type == "attachment" ||
+                    $wordpress->status == "attachment" ||
+                    $item->title == "zz_placeholder"
+                ) {
                     continue;
+                }
 
                 $media = array();
                 $regexp_url = preg_quote($_POST['media_url'], "/");
-                if (!empty($_POST['media_url']) and
-                    preg_match_all("/{$regexp_url}([^\.\!,\?;\"\'<>\(\)\[\]\{\}\s\t ]+)\.([a-zA-Z0-9]+)/",
-                                   $contentencoded,
-                                   $media))
+                if (!empty($_POST['media_url']) &&
+                    preg_match_all(
+                        "/{$regexp_url}([^\.\!,\?;\"\'<>\(\)\[\]\{\}\s\t ]+)\.([a-zA-Z0-9]+)/",
+                        $contentencoded,
+                        $media
+                    )
+                ) {
                     $media_uris = array_unique($media[0]);
                     foreach ($media_uris as $matched_url) {
                         $filename = upload_from_url($matched_url);
                         $contentencoded = str_replace($matched_url, $config->url.$config->uploads_path.$filename, $contentencoded);
                     }
-
+                }
+                
                 $clean = (isset($wordpress->post_name) && $wordpress->post_name != '') ? $wordpress->post_name : sanitize($item->title) ;
 
                 $pinned = (isset($wordpress->is_sticky)) ? $wordpress->is_sticky : 0 ;

--- a/modules/tags/tags.php
+++ b/modules/tags/tags.php
@@ -470,7 +470,7 @@
 
             $tags = array();
             foreach ($item->category as $tag)
-                if (isset($tag->attributes()->domain) and $tag->attributes()->domain == "tag" and !empty($tag) and isset($tag->attributes()->nicename))
+                if (!empty($tag) and isset($tag->attributes()->domain) and (substr_count($tag->attributes()->domain, "tag") > 0) and isset($tag->attributes()->nicename))
                     $tags[strip_tags(trim($tag))] = sanitize(strip_tags(trim($tag)));
 
             if (!empty($tags))

--- a/modules/wordpresstypeimport/info.yaml
+++ b/modules/wordpresstypeimport/info.yaml
@@ -1,8 +1,9 @@
-name: Wordpress Type Importer
-url: http://eye48.com/go/chyrp
+name: Wordpress Post Types Importer
+url: http://eye48.com/go/chyrpwordpressimport
 version: 1.0
-description: Supports various post types on Wordpress import.
+description: Importing Wordpress post types Link, Quote, Video and Image as the correct feather if it is enabled.
 author:
   name: Haschek
   url: http://michael.haschke.biz/
-conflicts:
+notifications:
+  - When importing posts make sure that the required feathers are enabled otherwise the posts will be imported as text feathers.

--- a/modules/wordpresstypeimport/info.yaml
+++ b/modules/wordpresstypeimport/info.yaml
@@ -1,0 +1,8 @@
+name: Wordpress Type Importer
+url: http://eye48.com/go/chyrp
+version: 1.0
+description: Supports various post types on Wordpress import.
+author:
+  name: Haschek
+  url: http://michael.haschke.biz/
+conflicts:

--- a/modules/wordpresstypeimport/wordpresstypeimport.php
+++ b/modules/wordpresstypeimport/wordpresstypeimport.php
@@ -88,4 +88,51 @@
             
             return $content;
         }
+        
+        public function import_wordpress_post_video($content, $item) {
+
+            // test if quote feather is activated
+
+            $config = Config::current();
+            if (!in_array("video", $config->enabled_feathers)) {
+                return $content;
+            }
+            
+            $videodata = array();
+            
+            // keep title
+            
+            $videodata['title'] = $content['content']['title'];
+        
+            $body = $content['content']['body'];
+            
+            // get first link in post body, it's the video url
+            
+            $urls = array();
+            if (preg_match('$https?\://{1}\S+$', $body, $urls) && count($urls) > 0) {
+                $videodata['video'] = $urls[0];
+                $videodata['embed'] = Video::embed_tag($videodata['video']);
+            }
+            
+            // everything else is the video caption
+            
+            if (isset($videodata['video'])) {
+                $videodata['caption'] = str_replace($videodata['video'], '', $body);
+            }
+            
+            if (
+                isset($videodata['title']) &&
+                isset($videodata['video']) &&
+                isset($videodata['embed']) &&
+                isset($videodata['caption'])
+               ) {
+                $content['feather'] = 'video';
+                $content['content'] = $videodata;
+                return $content;
+            }
+            
+            // fallback, return standard text post data
+            
+            return $content;
+        }
     }

--- a/modules/wordpresstypeimport/wordpresstypeimport.php
+++ b/modules/wordpresstypeimport/wordpresstypeimport.php
@@ -1,4 +1,10 @@
 <?php
+    /**
+     * Class: WordpressTypeImport
+     * Importing Wordpress post types Link, Quote, Video and Image as the correct feather if it is enabled.
+     *
+     * @author http://michael.haschke.biz/
+     */
     class WordpressTypeImport extends Modules {
     
         public function import_wordpress_enhancement() {

--- a/modules/wordpresstypeimport/wordpresstypeimport.php
+++ b/modules/wordpresstypeimport/wordpresstypeimport.php
@@ -46,4 +46,46 @@
             return $content;
         }
         
+        public function import_wordpress_post_quote($content, $item) {
+
+            // test if quote feather is activated
+
+            $config = Config::current();
+            if (!in_array("quote", $config->enabled_feathers)) {
+                return $content;
+            }
+            
+            $quotedata = array();
+        
+            $body = $content['content']['body'];
+            
+            // get first blockquote in content body
+            
+            $source_link_start = strpos($content['content']['body'], '<blockquote>');
+            
+            if ($source_link_start !== false) {
+                $source_link_end = strpos($content['content']['body'], '</blockquote>', $source_link_start + 12);
+                
+                if ($source_link_end !== false) {
+                    $quotedata['quote'] = substr($content['content']['body'], $source_link_start + 12, $source_link_end - $source_link_start - 12);
+                }
+            }
+            
+            // source description is everything after the first paragraph
+            
+            $quotedata['source'] = substr($content['content']['body'], strpos($content['content']['body'], '</blockquote>') + 13);
+
+            if (
+                isset($quotedata['quote']) &&
+                isset($quotedata['source'])
+               ) {
+                $content['feather'] = 'quote';
+                $content['content'] = $quotedata;
+                return $content;
+            }
+            
+            // fallback, return standard text post data
+            
+            return $content;
+        }
     }

--- a/modules/wordpresstypeimport/wordpresstypeimport.php
+++ b/modules/wordpresstypeimport/wordpresstypeimport.php
@@ -1,5 +1,11 @@
 <?php
     class WordpressTypeImport extends Modules {
+    
+        public function import_wordpress_enhancement() {
+            
+            return '<p>'.__('When importing posts make sure that the required feathers are enabled otherwise the posts will be imported as text feathers.').'</p>';
+        }
+    
         public function import_wordpress_post_link($content, $item) {
 
             // test if link feather is activated

--- a/modules/wordpresstypeimport/wordpresstypeimport.php
+++ b/modules/wordpresstypeimport/wordpresstypeimport.php
@@ -1,0 +1,49 @@
+<?php
+    class WordpressTypeImport extends Modules {
+        public function import_wordpress_post_link($content, $item) {
+
+            // test if link feather is activated
+
+            $config = Config::current();
+            if (!in_array("link", $config->enabled_feathers)) {
+                return $content;
+            }
+            
+            $linkdata = array();
+        
+            $linkdata['name'] = $content['content']['title'];
+            
+            $body = $content['content']['body'];
+            
+            // get first link in content body
+            
+            $source_link_start = strpos($content['content']['body'], 'href="');
+            
+            if ($source_link_start !== false) {
+                $source_link_end = strpos($content['content']['body'], '"', $source_link_start + 6);
+                
+                if ($source_link_end !== false) {
+                    $linkdata['source'] = substr($content['content']['body'], $source_link_start + 6, $source_link_end - $source_link_start - 6);
+                }
+            }
+            
+            // description is everything after the first paragraph
+            
+            $linkdata['description'] = substr($content['content']['body'], strpos($content['content']['body'], '</p>') + 4);
+
+            if (
+                isset($linkdata['name']) &&
+                isset($linkdata['source']) &&
+                isset($linkdata['description'])
+               ) {
+                $content['feather'] = 'link';
+                $content['content'] = $linkdata;
+                return $content;
+            }
+            
+            // fallback, return standard text post data
+            
+            return $content;
+        }
+        
+    }


### PR DESCRIPTION
Fixes:
- enable imports from wordpress.com
- tag import
- category import
- check wp:post_type to prevent processing of attachment posts
- correct media url replacement

Enable post types:
- add module that imports typed Wordpress posts (link, quote, video, image) to the right Chyrp feathers (link, quote, video, photo) if they are enabled. Other/unknown post types are still imported as text feather.
