### PR TITLE
Sanitizing input for error.php

### DIFF
--- a/includes/error.php
+++ b/includes/error.php
@@ -1,4 +1,15 @@
 <?php
+    if (!class_exists("MainController")) {
+        if (defined("INCLUDES_DIR")) {
+            require INCLUDES_DIR."controller/Main.php";
+        } else {
+            header("Status: 403"); exit("Access denied."); # Undefined constants: xss protection.
+        }
+    }
+
+    if (class_exists("Route"))
+        Route::current(MainController::current());
+
     if (defined('AJAX') and AJAX or isset($_POST['ajax'])) {
         foreach ($backtrace as $trace)
             $body.= "\n"._f("%s on line %d", array($trace["file"], fallback($trace["line"], 0)));
@@ -8,12 +19,6 @@
     $jquery = is_callable(array("Config", "current")) ?
               Config::current()->url."/includes/lib/gz.php?file=jquery.js" :
               "http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js" ;
-
-    if (!class_exists("MainController"))
-        require INCLUDES_DIR."/controller/Main.php";
-
-    if (class_exists("Route"))
-        Route::current(MainController::current());
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -47,6 +47,10 @@
      *     $backtrace - The trace of the error.
      */
     function error($title, $body, $backtrace = array()) {
+        # Sanitize input
+        $title = fix($title);
+        $body = fix($body);
+
         if (defined('MAIN_DIR') and !empty($backtrace))
             foreach ($backtrace as $index => &$trace) {
                 if (!isset($trace["file"]) or !isset($trace["line"])) {
@@ -97,8 +101,8 @@
         # Display the error.
         if (defined('THEME_DIR') and class_exists("Theme") and Theme::current()->file_exists("pages/error"))
             MainController::current()->display("pages/error",
-                                               array("title" => fix($title),
-                                                     "body" => fix($body),
+                                               array("title" => $title,
+                                                     "body" => $body,
                                                      "backtrace" => $backtrace));
         else
             require INCLUDES_DIR."/error.php";

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -48,11 +48,13 @@
      */
     function error($title, $body, $backtrace = array()) {
         if (defined('MAIN_DIR') and !empty($backtrace))
-            foreach ($backtrace as $index => &$trace)
-                if (!isset($trace["file"]) or !isset($trace["line"]))
+            foreach ($backtrace as $index => &$trace) {
+                if (!isset($trace["file"]) or !isset($trace["line"])) {
                     unset($backtrace[$index]);
-                else
-                    $trace["file"] = str_replace(MAIN_DIR."/", "", $trace["file"]);
+                } else {
+                    $trace["line"] = fix($trace["line"]);
+                    $trace["file"] = fix(str_replace(MAIN_DIR."/", "", $trace["file"]));
+                }
                 # $trace["file"] = isset($trace["file"]) ?
                 #                       :
                 #                      (isset($trace["function"]) ?
@@ -60,6 +62,7 @@
                 #                              $trace["class"].$trace["type"] :
                 #                              "").$trace["function"] :
                 #                          "[internal]");
+            }
 
         # Clear all output sent before this error.
         if (($buffer = ob_get_contents()) !== false) {
@@ -94,8 +97,8 @@
         # Display the error.
         if (defined('THEME_DIR') and class_exists("Theme") and Theme::current()->file_exists("pages/error"))
             MainController::current()->display("pages/error",
-                                               array("title" => $title,
-                                                     "body" => $body,
+                                               array("title" => fix($title),
+                                                     "body" => fix($body),
                                                      "backtrace" => $backtrace));
         else
             require INCLUDES_DIR."/error.php";


### PR DESCRIPTION
Could be an xss issue in error.php – unchecked input.

The helper function `error()` has been modified to sanitize input. In
addition, error.php now tests a constant and throws 403 if not defined.
As far as I can tell, error.php should never be called in a situation
where common.php has not been included – only reason for constants to
be undefined is a direct browser request.
