### PR TITLE
Typo fix in error.php

### DIFF
--- a/gettext.rb
+++ b/gettext.rb
@@ -24,17 +24,29 @@ ARGV.options do |o|
   o.separator ""
 
   o.on("--project=[val]", String,
-       "The name of the project the .pot file is for.") { OPTIONS[:project] }
+       "The name of the project the .pot file is for.") do |project|
+    OPTIONS[:project] = project
+  end
   o.on("--maintainer=[val]", String,
-       "The maintainer of the .pot file. (Firstname Lastname <foo@bar.com>)") { OPTIONS[:maintainer] }
+       "The maintainer of the .pot file. (Firstname Lastname <foo@bar.com>)") do |maintainer|
+    OPTIONS[:maintainer] = maintainer
+  end
   o.on("--domain=[val]", String,
-       "Domain to scan for translations.") { OPTIONS[:domain] }
+       "Domain to scan for translations.") do |domain|
+    OPTIONS[:domain] = domain
+  end
   o.on("--msgstr=[val]", String,
-       "Message string to translate all found translations to. Useful for debugging.") { OPTIONS[:mststr] }
+       "Message string to translate all found translations to. Useful for debugging.") do |msgstr|
+    OPTIONS[:mststr] = msgstr
+  end
   o.on("--exclude=[val1,val2]", Array,
-       "A list of directories to exclude from the scan.") { OPTIONS[:exclude] }
+       "A list of directories to exclude from the scan.") do |exclude|
+    OPTIONS[:exclude] = exclude
+  end
   o.on("--keys=[val1,val2]", Array,
-       "A list of YAML keys for which to generate translations.") { OPTIONS[:keys] }
+       "A list of YAML keys for which to generate translations.") do |keys|
+    OPTIONS[:keys] = keys
+  end
 
   o.separator ""
 

--- a/includes/error.php
+++ b/includes/error.php
@@ -1,7 +1,7 @@
 <?php
     if (!class_exists("MainController")) {
         if (defined("INCLUDES_DIR")) {
-            require INCLUDES_DIR."controller/Main.php";
+            require INCLUDES_DIR."/controller/Main.php";
         } else {
             header("Status: 403"); exit("Access denied."); # Undefined constants: xss protection.
         }


### PR DESCRIPTION
Fixed silly typo in error.php that was causing an exception.

Also fixed gettext.rb (which seems to be broken in Ruby 2.0) by conforming to Ruby 2.1 [example code](http://ruby-doc.org/stdlib-2.1.0/libdoc/optparse/rdoc/OptionParser.html).
