### PR TITLE
Replaced admin help popup with iframe overlay

### DIFF
--- a/admin/help.php
+++ b/admin/help.php
@@ -49,6 +49,7 @@
                 padding: .25em 1em;
                 background: #f0f0f0;
                 margin: 0 -1em 1em;
+                white-space: pre-wrap;
             }
             .body ul,
             .body ol {

--- a/admin/themes/default/javascript.php
+++ b/admin/themes/default/javascript.php
@@ -15,6 +15,62 @@ $(function(){
 
     if (Route.action == "modules" || Route.action == "feathers")
         Extend.init()
+
+    // Open help text in an iframe overlay
+    $(".help").on("click", function(){
+        $("<div>", {
+            "id": "ChyrpHelp-div",
+            "role": "region",
+        }).css({
+            "display": "block",
+            "position": "fixed",
+            "width": "100%",
+            "height": "100%",
+            "top": "0px",
+            "left": "0px",
+            "background-color": "rgba(79, 79, 79, 0.5)"
+        }).append(
+            [$("<iframe>", {
+                "id": "ChyrpHelp-frame",
+                "src": $(this).attr("href"),
+                "role": "contentinfo",
+                "aria-label": "Help"
+            }).css({
+                "display": "block",
+                "position": "absolute",
+                "width": "80%",
+                "height": "80%",
+                "max-height": "640px",
+                "top": "10%",
+                "left": "10%",
+                "overflow-x": "hidden",
+                "overflow-y": "auto",
+                "border": "none",
+                "box-shadow": "0px 4px 16px 2px rgba(79, 79, 79, 0.5)"    
+            }),
+            $("<img>", {
+                "src": "<?php echo $config->chyrp_url."/admin/themes/".$config->admin_theme; ?>/images/icons/cancel.svg",
+                "alt": "<?php echo ( __("Cancel") ) ?>",
+                "role": "button",
+                "aria-label": "<?php echo ( __("Cancel") ) ?>"
+            }).css({
+                "display": "block",
+                "position": "absolute",
+                "width": "16px",
+                "height": "16px",
+                "top": "10%",
+                "right": "10%",
+                "padding-top": "8px",
+                "padding-right": "8px",
+                "cursor": "pointer"
+            }).click(function() {
+                $(this).parent().remove();
+            })]
+        ).click(function() {
+            $(this).remove();
+        }).insertAfter("#content");
+        return false;
+    });
 })
 
 var Write = {

--- a/includes/admin.js.php
+++ b/includes/admin.js.php
@@ -53,13 +53,6 @@ $(function(){
     })
     <?php endif; ?>
 
-    // "Help" links should open in popup windows.
-    $(".help").live("click", function(){
-        window.open($(this).attr("href"), "help", "status=0, scrollbars=1, location=0, menubar=0, "+
-                                                  "toolbar=0, resizable=1, height=450, width=400")
-        return false
-    })
-
     // SVG fallback for browsers that do not support SVG images
     $("img").fixsvg()
 


### PR DESCRIPTION
1. Better experience for non-windowed browsers (smartphones).
2. Help page opens without delay because it avoids the browser’s popup protection.
3. Overlay resizes with the viewport, good all the way down to mobile sizes.
4. Overlay can be closed by tapping the periphery as well as using the X gadget.

I've also moved this behaviour to the admin theme's JavaScript – I think this behaviour is a choice the theme maker should be able to control.

Screenshot of the new help overlay:
![screen shot 2014-06-22 at 10 46 28](https://cloud.githubusercontent.com/assets/4855211/3351157/d77cfc06-f9f6-11e3-90f2-230902088817.png)
