### PR TITLE
Tagginator: added removal of tags on uninstall

### DIFF
--- a/modules/tags/tags.php
+++ b/modules/tags/tags.php
@@ -11,6 +11,16 @@
 
         static function __uninstall($confirm) {
             Route::current()->remove("tag/(name)/");
+
+            if ($confirm) {
+                $sql = SQL::current();
+
+                foreach($sql->select("post_attributes",
+                                     "*",
+                                     array("name" => "tags"))->fetchAll() as $post)  {
+                    $sql->delete("post_attributes", array("name" => "tags", "post_id" => $post["post_id"]));
+                }
+            }
         }
 
         public function admin_head() {


### PR DESCRIPTION
Upon confirm, remove tags attributes from the database. Seems to have been left unimplemented for some reason…
