### PR TITLE
Made update checking more sane

### DIFF
--- a/includes/class/Update.php
+++ b/includes/class/Update.php
@@ -18,8 +18,13 @@
          * Checks if the a new version of Chyrp is available.
          */
         public static function check_update() {
-            if (!Config::current()->check_updates)
+            $config = Config::current();
+
+            if (!$config->check_updates)
                 return;
+
+            if ((time() - $config->check_updates_last) < 86400 )
+                return; # Check for updates once per day
 
             $xml = self::xml();
             $curver = CHYRP_VERSION;
@@ -34,6 +39,8 @@
                     break;
                 }
             }
+
+            $config->set("check_updates_last", time());
 
             return $return;
         }

--- a/install.php
+++ b/install.php
@@ -139,6 +139,7 @@
             $config->set("timezone", $_POST['timezone']);
             $config->set("locale", "en_US");
             $config->set("check_updates", true);
+            $config->set("check_updates_last", 0);
             $config->set("theme", "firecrest");
             $config->set("admin_theme", "default");
             $config->set("posts_per_page", 5);

--- a/upgrade.php
+++ b/upgrade.php
@@ -1346,6 +1346,9 @@
         Config::remove("rss_posts");
         Config::remove("time_offset");
 
+        // Added in 2.6
+        Config::fallback("check_updates_last", 0);
+
         move_upload();
 
         remove_database_config_file();


### PR DESCRIPTION
One check per day should be adequate, no need to put so much load on the update server or to subject users to the possibility of constant admin page loading delays due to slow connection to the update server.
