### PR TITLE
Photo feather: added support for image source sets

### DIFF
--- a/feathers/photo/photo.php
+++ b/feathers/photo/photo.php
@@ -129,7 +129,14 @@
         public function image_tag($post, $max_width = 510, $max_height = null, $more_args = "quality=100") {
             $config = Config::current();
             $alt = !empty($post->alt_text) ? fix($post->alt_text, true) : $post->filename ;
-            return '<img src="'.$config->chyrp_url.'/includes/thumb.php?file=..'.$config->uploads_path.urlencode($post->filename).'&amp;max_width='.$max_width.'&amp;max_height='.$max_height.'&amp;'.$more_args.'" alt="'.$alt.'" class="image" />';
+
+            # Source set for responsive images
+            $srcset = array($config->chyrp_url.'/includes/thumb.php?file=..'.$config->uploads_path.urlencode($post->filename).'&amp;max_width='.$max_width.'&amp;max_height='.$max_height.'&amp;'.$more_args.' 1x',
+                            $config->chyrp_url.'/includes/thumb.php?file=..'.$config->uploads_path.urlencode($post->filename).'&amp;max_width=960&amp;'.$more_args.' 960w',
+                            $config->chyrp_url.'/includes/thumb.php?file=..'.$config->uploads_path.urlencode($post->filename).'&amp;max_width=640&amp;'.$more_args.' 640w',
+                            $config->chyrp_url.'/includes/thumb.php?file=..'.$config->uploads_path.urlencode($post->filename).'&amp;max_width=320&amp;'.$more_args.' 320w');
+
+            return '<img srcset="'.implode(", ", $srcset).'" src="'.$config->chyrp_url.'/includes/thumb.php?file=..'.$config->uploads_path.urlencode($post->filename).'&amp;max_width='.$max_width.'&amp;max_height='.$max_height.'&amp;'.$more_args.'" alt="'.$alt.'" class="image" />';
         }
 
         public function image_link($post, $max_width = 510, $max_height = null, $more_args = "quality=100") {

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -76,7 +76,7 @@
             if (empty($_POST['author'])) error(__("Error"), __("Author can't be blank.", "comments"));
             if (empty($_POST['email']))  error(__("Error"), __("E-Mail address can't be blank.", "comments"));
 
-            fallback($parent, (int) !empty($_POST['parent_id']));
+            fallback($parent, (int) $_POST['parent_id'], 0);
             fallback($notify, (int) !empty($_POST['notify']));
 
             Comment::create($_POST['body'],


### PR DESCRIPTION
Photo feather will now generate a `srcset` with image sizes at several common breakpoints: 960w, 640w, 320w, plus the size requested by the twig. The use of a source set allows user agents to select the most optimal image to download.
