### PR TITLE
fixed comments selection #222

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -698,7 +698,7 @@
             return fallback($this->latest_comments[$post->id], null);
         }
 
-        public function comments_get($options) {
+        public function comments_get(&$options) {
             if (ADMIN)
                 return;
 

--- a/modules/comments/model.Comment.php
+++ b/modules/comments/model.Comment.php
@@ -122,9 +122,6 @@
                                          $parent,
                                          $notify);
 
-                    fallback($_SESSION['comments'], array());
-                    $_SESSION['comments'][] = $comment->id;
-
                     if (isset($_POST['ajax']))
                         exit("{ \"comment_id\": \"".$comment->id."\", \"comment_timestamp\": \"".$comment->created_at."\" }");
 
@@ -142,9 +139,6 @@
                                      $visitor->id,
                                      $parent,
                                      $notify);
-
-                fallback($_SESSION['comments'], array());
-                $_SESSION['comments'][] = $comment->id;
 
                 if (isset($_POST['ajax']))
                     exit("{ \"comment_id\": \"".$comment->id."\", \"comment_timestamp\": \"".$comment->created_at."\" }");
@@ -197,7 +191,11 @@
                                "created_at" => oneof($created_at, datetime()),
                                "updated_at" => oneof($updated_at, "0000-00-00 00:00:00")));
 
-            $new = new self($sql->latest("comments"));
+            $comment_id = $sql->latest("comments");
+            fallback($_SESSION['comments'], array());
+            $_SESSION['comments'][] = $comment_id;
+            
+            $new = new self($comment_id);
             Trigger::current()->call("add_comment", $new);
             self::notify(strip_tags($author), $body, $post);
             return $new;


### PR DESCRIPTION
SQL filter settings wasn't taken since $options weren't used by reference - in this case every user sees every comment disregarding wether its denied or not.
