### PR TITLE
Likes: bug fix – check for keys before creating

### DIFF
--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -215,11 +215,13 @@
             if ($post->no_results)
                 return false;
 
-            Comment::create($blog_name,
+            Comment::create('<strong><a href="'.fix($url).'">'.fix($title).'</a></strong>'."\n".$excerpt,
                             "",
                             $_POST["url"],
-                            '<strong><a href="'.fix($url).'">'.fix($title).'</a></strong>'."\n".$excerpt,
+                            $blog_name,
                             $post,
+                            0,
+                            0,
                             "trackback");
         }
 
@@ -231,11 +233,13 @@
             if ($count)
                 return new IXR_Error(48, __("A ping from that URL is already registered.", "comments"));
 
-            Comment::create($title,
+            Comment::create($excerpt,
                             "",
                             $from,
-                            $excerpt,
+                            $title,
                             $post,
+                            0,
+                            0,
                             "pingback");
         }
 

--- a/modules/likes/model.Like.php
+++ b/modules/likes/model.Like.php
@@ -126,22 +126,24 @@
         }
 
         static function install() {
-            SQL::current()->query("CREATE TABLE IF NOT EXISTS __likes (
-                                     id INTEGER PRIMARY KEY AUTO_INCREMENT,
-                                     post_id INTEGER NOT NULL,
-                                     user_id INTEGER NOT NULL,
-                                     timestamp DATETIME DEFAULT NULL,
-                                     session_hash VARCHAR(32) NOT NULL
-                                   ) DEFAULT CHARSET=UTF8");
+            $sql = SQL::current();
 
-            $constraints = SQL::current()->query("SELECT COUNT(*) AS unique_keys FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
-                                                  WHERE (TABLE_SCHEMA = DATABASE()
-                                                    AND TABLE_NAME = '__likes'
-                                                    AND CONSTRAINT_TYPE = 'UNIQUE')")->fetchObject();
+            $sql->query("CREATE TABLE IF NOT EXISTS __likes (
+                          id INTEGER PRIMARY KEY AUTO_INCREMENT,
+                          post_id INTEGER NOT NULL,
+                          user_id INTEGER NOT NULL,
+                          timestamp DATETIME DEFAULT NULL,
+                          session_hash VARCHAR(32) NOT NULL
+                        ) DEFAULT CHARSET=UTF8");
 
-            if ($constraints->unique_keys === 0) {
-              SQL::current()->query("CREATE INDEX key_post_id ON __likes (post_id)");
-              SQL::current()->query("CREATE UNIQUE INDEX key_post_id_sh_pair ON __likes (post_id, session_hash)");
+            $constraints = $sql->query("SELECT COUNT(*) AS unique_keys FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+                                        WHERE (TABLE_NAME = '__likes'
+                                          AND CONSTRAINT_NAME = 'key_post_id_sh_pair'
+                                          AND CONSTRAINT_TYPE = 'UNIQUE')")->fetchObject();
+
+            if ($constraints->unique_keys == 0) {
+              $sql->query("CREATE INDEX key_post_id ON __likes (post_id)");
+              $sql->query("CREATE UNIQUE INDEX key_post_id_sh_pair ON __likes (post_id, session_hash)");
             }
 
             Group::add_permission("like_post", "Like Posts");

--- a/modules/likes/model.Like.php
+++ b/modules/likes/model.Like.php
@@ -133,8 +133,16 @@
                                      timestamp DATETIME DEFAULT NULL,
                                      session_hash VARCHAR(32) NOT NULL
                                    ) DEFAULT CHARSET=UTF8");
-            SQL::current()->query("CREATE INDEX key_post_id ON __likes (post_id)");
-            SQL::current()->query("CREATE UNIQUE INDEX key_post_id_sh_pair ON __likes (post_id, session_hash)");
+
+            $constraints = SQL::current()->query("SELECT COUNT(*) AS unique_keys FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+                                                  WHERE (TABLE_SCHEMA = DATABASE()
+                                                    AND TABLE_NAME = '__likes'
+                                                    AND CONSTRAINT_TYPE = 'UNIQUE')")->fetchObject();
+
+            if ($constraints->unique_keys === 0) {
+              SQL::current()->query("CREATE INDEX key_post_id ON __likes (post_id)");
+              SQL::current()->query("CREATE UNIQUE INDEX key_post_id_sh_pair ON __likes (post_id, session_hash)");
+            }
 
             Group::add_permission("like_post", "Like Posts");
             Group::add_permission("unlike_post", "Unlike Posts");

--- a/modules/tags/tags.php
+++ b/modules/tags/tags.php
@@ -317,6 +317,9 @@
         }
 
         public function admin_delete_tag($admin) {
+            if (!Visitor::current()->group->can("edit_post"))
+                show_403(__("Access Denied"), __("You do not have sufficient privileges to delete tags.", "tags"));
+
             $sql = SQL::current();
 
             foreach($sql->select("post_attributes",


### PR DESCRIPTION
The likes module might have been enabled previously and then disabled without removing the table from the database; this query ensures we don’t try to create keys if they already exist (resulting in an error).

This query should be database agnostic since INFORMATION_SCHEME is an ANSI standard.
